### PR TITLE
Set application name to the Tenejo product name

### DIFF
--- a/app/helpers/hyrax_helper.rb
+++ b/app/helpers/hyrax_helper.rb
@@ -3,4 +3,8 @@ module HyraxHelper
   include ::BlacklightHelper
   include Hyrax::BlacklightOverride
   include Hyrax::HyraxHelperBehavior
+
+  def application_name
+    t('tenejo.application_name', default: super)
+  end
 end

--- a/config/locales/tenejo.en.yml
+++ b/config/locales/tenejo.en.yml
@@ -1,5 +1,6 @@
 ---
 en:
   tenejo:
+    application_name: Tenejo
     product_name: Tenejo
     institution_name: Tenejo @ OR2018

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -64,7 +64,7 @@ RSpec.feature 'Create a Work', js: false do
 
       click_on('Save')
       expect(page).to have_content('My Test Work')
-      expect(page).to have_content "Your files are being processed by Hyrax in the background."
+      expect(page).to have_content "Your files are being processed"
     end
   end
 end


### PR DESCRIPTION
Hyrax had hard coded this to `hyrax.product_name` which is used to represent the Hyrax project elsewhere in the application (e.g. it is displayed alongside the Hyrax version number).