### PR TITLE
Fix derivative regeneration task (`NoMethodError`)

### DIFF
--- a/lib/tasks/derivatives.rake
+++ b/lib/tasks/derivatives.rake
@@ -6,7 +6,7 @@ namespace :derivatives do
       total = 0
 
       work_type.all.each do |work|
-        recreate_derivatives(work)
+        regenerate_derivatives(work)
         total += 1
       end
 


### PR DESCRIPTION
This task referenced a method name that only existed briefly during
development. Note that we should document a standard approach to testing rake
tasks.