### PR TITLE
Change solr version to one that still provides md5

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -1,5 +1,5 @@
 # Place any default configuration for solr_wrapper here
-# version: 6.0.0
+version: 6.6.5
 # port: 8983
 instance_dir: tmp/solr-development
 collection:

--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -1,5 +1,5 @@
 #config/solr_wrapper_test.yml
-# version: 6.1.0
+version: 6.6.5
 port: 8985
 instance_dir: tmp/solr-test
 collection:


### PR DESCRIPTION
Solr has stopped providing an md5 checksum, which solr
wrapper is looking for. Pin solr version to 6.6.5, the last
version that still seems to have an md5 checksum.