### PR TITLE
Use BRANCH_NAME or BRANCH to deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -51,7 +51,7 @@ set :assets_prefix, "#{shared_path}/public/assets"
 
 SSHKit.config.command_map[:rake] = 'bundle exec rake'
 
-set :branch, ENV['REVISION'] || ENV['BRANCH'] || 'master'
+set :branch, ENV['REVISION'] || ENV['BRANCH'] || ENV['BRANCH_NAME'] || 'master'
 
 append :linked_dirs, "log"
 append :linked_dirs, "public/assets"


### PR DESCRIPTION
BRANCH_NAME is commonly used in many of our code
bases and I'm in the habit of using it. Let's keep
it for backward compatibility because it causes
unexpected problems if it isn't enabled and one
tries to use it.