### PR TITLE
Upload a CSV manifest. Connected to #45

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -15,3 +15,10 @@ FIRST_USER_PASSWORD=123456
 ADMIN_EMAIL=admin@example.com
 ADMIN_DISPLAY_NAME=Marie Curie
 ADMIN_PASSWORD=123456
+
+# Storage dir for CSV manifest files (for CSV importer).
+# These should use an absolute path in production.  If you use a relative path, it seems to put it under the 'public' directory in the Rails root, which would be a security risk.
+# You don't necessarily need to set these.  If not set, tenejo will use the Hyrax upload path and cache path.
+# CSV_MANIFESTS_PATH=tmp/csv_uploads
+# CSV_MANIFESTS_CACHE_PATH=tmp/csv_uploads/cache
+

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 
 .byebug_history
 .env.development
+
+csv_uploads

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,8 +11,28 @@ Metrics/BlockLength:
     - 'config/**/*'
     - 'spec/features**/*'
     - lib/tasks/tenejo.rake
+    - 'spec/controllers/csv_imports_controller_spec.rb'
+    - 'spec/uploaders/csv_manifest_validator_spec.rb'
+    - 'spec/uploaders/csv_manifest_uploader_spec.rb'
+
+RSpec/AnyInstance:
+  Enabled: false
+
+Rails/Delegate:
+  Exclude:
+    - 'app/models/csv_import.rb'
 
 RSpec/ExampleLength:
   Enabled: true
   Exclude:
     - 'spec/features**/*'
+
+Style/BlockDelimiters:
+  Exclude:
+    - 'spec/controllers/csv_imports_controller_spec.rb'
+
+Style/EmptyMethod:
+  Enabled: false
+
+Style/PercentLiteralDelimiters:
+  Enabled: false

--- a/app/controllers/csv_imports_controller.rb
+++ b/app/controllers/csv_imports_controller.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class CsvImportsController < ApplicationController
+  load_and_authorize_resource
+  before_action :load_and_authorize_preview, only: [:preview]
+
+  with_themed_layout 'dashboard'
+
+  def index
+  end
+
+  def show
+  end
+
+  def new
+  end
+
+  # Validate the CSV file and display errors or
+  # warnings to the user.
+  def preview
+  end
+
+  def create
+    @csv_import.user = current_user
+    preserve_cache
+
+    if @csv_import.save
+      redirect_to @csv_import
+    else
+      render :new
+    end
+  end
+
+  private
+
+    def load_and_authorize_preview
+      @csv_import = CsvImport.new(create_params)
+      authorize! :create, @csv_import
+    end
+
+    def create_params
+      params.fetch(:csv_import, {}).permit(:manifest)
+    end
+
+    # Since we are re-rendering the form (once for
+    # :new and again for :preview), we need to
+    # manually set the cache, otherwise the record
+    # will lose the manifest file between the preview
+    # and the record save.
+    def preserve_cache
+      return unless params['csv_import']
+      @csv_import.manifest_cache = params['csv_import']['manifest_cache']
+    end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -18,5 +18,7 @@ class Ability
     # if user_groups.include? 'special_group'
     #   can [:create], ActiveFedora::Base
     # end
+
+    can :manage, CsvImport if current_user.admin?
   end
 end

--- a/app/models/csv_import.rb
+++ b/app/models/csv_import.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CsvImport < ApplicationRecord
+  belongs_to :user
+  mount_uploader :manifest, CsvManifestUploader
+
+  def manifest_warnings
+    manifest.warnings
+  end
+
+  def manifest_errors
+    manifest.errors
+  end
+end

--- a/app/uploaders/csv_manifest_uploader.rb
+++ b/app/uploaders/csv_manifest_uploader.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class CsvManifestUploader < CarrierWave::Uploader::Base
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+
+  # Process calls that method whenever a file is uploaded.
+  process :validate_csv
+
+  # The directory where the csv manifest will be stored.
+  def store_dir
+    configured_upload_path + "#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  def cache_dir
+    configured_cache_path + "#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  #   %w(jpg jpeg gif png)
+  def extension_whitelist
+    %w(csv)
+  end
+
+  # These are stored in memory only, not persisted
+  def errors
+    @validator ? @validator.errors : []
+  end
+
+  # These are stored in memory only, not persisted
+  def warnings
+    @validator ? @validator.warnings : []
+  end
+
+  private
+
+    def validate_csv
+      @validator = CsvManifestValidator.new(self)
+      @validator.validate
+    end
+
+    def configured_upload_path
+      ENV['CSV_MANIFESTS_PATH'] || Hyrax.config.upload_path.call + 'csv_uploads'
+    end
+
+    def configured_cache_path
+      ENV['CSV_MANIFESTS_CACHE_PATH'] || Hyrax.config.cache_path.call + 'csv_uploads/cache'
+    end
+end

--- a/app/uploaders/csv_manifest_validator.rb
+++ b/app/uploaders/csv_manifest_validator.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Validate a CSV file.
+#
+# Don't put expensive validations in this class.
+# This is meant to be used for running a few quick
+# validations before starting a CSV-based import.
+# It will be called during the HTTP request/response,
+# so long-running validations will make the page load
+# slowly for the user.  Any validations that are slow
+# should be run in background jobs during the import
+# instead of here.
+
+class CsvManifestValidator
+  # @param manifest_uploader [CsvManifestUploader] The manifest that's mounted to a CsvImport record.  See carrierwave gem documentation.  This is basically a wrapper for the CSV file.
+  def initialize(manifest_uploader)
+    @csv_file = manifest_uploader.file
+    @errors = []
+    @warnings = []
+  end
+
+  # Errors and warnings for the CSV file.
+  attr_reader :errors, :warnings
+  attr_reader :csv_file
+
+  def validate
+    @rows = CSV.read(csv_file.path)
+
+    missing_headers
+    unrecognized_headers
+  end
+
+  # One record per row
+  def record_count
+    return nil unless @rows
+    @rows.size - 1 # Don't include the header row
+  end
+
+  def valid_headers
+    ['title', 'files', 'representative_media',
+     'thumbnail', 'rendering', 'depositor',
+     'date_uploaded', 'date_modified', 'label',
+     'relative_path', 'import_url', 'resource_type',
+     'creator', 'contributor', 'description',
+     'keyword', 'license', 'rights_statement',
+     'publisher', 'date_created', 'subject',
+     'language', 'identifier', 'based_near',
+     'related_url', 'bibliographic_citation',
+     'source', 'visibility']
+  end
+
+private
+
+  def missing_headers
+    return if @rows.first.include?('title')
+    @errors << 'Missing required column: "title".  Your spreadsheet must have this column.  If you already have this column, please check the spelling and capitalization.'
+  end
+
+  # Warn the user if we find any unexpected headers.
+  def unrecognized_headers
+    extra_headers = @rows.first - valid_headers
+    extra_headers.each do |header|
+      @warnings << "The field name \"#{header}\" is not supported.  This field will be ignored, and the metadata for this field will not be imported."
+    end
+    extra_headers
+  end
+end

--- a/app/views/csv_imports/_form.html.erb
+++ b/app/views/csv_imports/_form.html.erb
@@ -1,0 +1,24 @@
+<%= form_with(model: csv_import, local: true, html: { multipart: true }, url: preview_csv_import_path) do |form| %>
+
+  <% if csv_import.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(csv_import.errors.size, "error") %> prohibited this csv_import from being saved:</h2>
+
+      <ul>
+      <% csv_import.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <p>
+    <label>Select your CSV Manifest</label>
+    <%= form.file_field :manifest, required: true %>
+    <%= form.hidden_field :manifest_cache %>
+  </p>
+
+  <div class="actions">
+    <%= form.submit 'Preview Import' %>
+  </div>
+<% end %>

--- a/app/views/csv_imports/_start_import_form.html.erb
+++ b/app/views/csv_imports/_start_import_form.html.erb
@@ -1,0 +1,8 @@
+<%= form_with(model: csv_import, local: true, html: { multipart: true }) do |form| %>
+
+  <%= form.hidden_field :manifest_cache %>
+
+  <div class="actions">
+    <%= form.submit 'Start Import' %>
+  </div>
+<% end %>

--- a/app/views/csv_imports/index.html.erb
+++ b/app/views/csv_imports/index.html.erb
@@ -1,0 +1,21 @@
+<p id="notice"><%= notice %></p>
+
+<h2>CSV Imports</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @csv_imports.each do |csv_import| %>
+      <tr>
+        <td><%= csv_import.id %></td>
+        <td><%= link_to 'Show', csv_import %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+

--- a/app/views/csv_imports/new.html.erb
+++ b/app/views/csv_imports/new.html.erb
@@ -1,0 +1,2 @@
+<h2> Import a set of records </h2>
+<%= render 'form', csv_import: @csv_import %>

--- a/app/views/csv_imports/preview.html.erb
+++ b/app/views/csv_imports/preview.html.erb
@@ -1,0 +1,42 @@
+<h2> Preview of your CSV-based Import </h2>
+
+<div id='csv_info'>
+  <% if @csv_import.manifest.file %>
+    <label> CSV Manifest: </label>
+    <%= File.basename(@csv_import.manifest.to_s) %>
+  <% end %>
+  <br />
+
+  <p> TODO: This import will add XXX new records. </p>
+</div>
+
+<% unless @csv_import.manifest_errors.empty? %>
+  <div id='csv_errors'>
+    The CSV file has the following errors:
+    <ul>
+      <% @csv_import.manifest_errors.each do |error| %>
+        <li> <%= error %> </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<% unless @csv_import.manifest_warnings.empty? %>
+  <div id='csv_warnings'>
+    The CSV file has the following warnings:
+    <ul>
+      <% @csv_import.manifest_warnings.each do |warning| %>
+        <li> <%= warning %> </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<% if @csv_import.manifest_errors.empty? %>
+  <%= link_to 'Cancel', new_csv_import_path %>
+  <br />
+  <%= render 'start_import_form', csv_import: @csv_import %>
+<% else %>
+  <p> You will need to correct the errors with the CSV file before you can continue. </p>
+  <%= link_to 'Try Again', new_csv_import_path %>
+<% end %>

--- a/app/views/csv_imports/show.html.erb
+++ b/app/views/csv_imports/show.html.erb
@@ -1,0 +1,16 @@
+<h2> Importing Records from a CSV File </h2>
+<p id="notice"><%= notice %></p>
+
+<p>
+  <label> CSV Manifest: </label>
+  <span> <%= File.basename(@csv_import.manifest.to_s) %> </span>
+  <br />
+  <label> Uploaded by: </label>
+  <span> <%= @csv_import.user.name %> </span>
+  <br />
+  <label> Start time: </label>
+  <span> <%= @csv_import.created_at %> </span>
+</p>
+
+<p> TODO: Put info about the current status of the import here. </p>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,9 @@
 require 'sidekiq/web'
 
 Rails.application.routes.draw do
+  resources :csv_imports, only: [:index, :show, :new, :create]
+  post 'csv_imports/preview', as: 'preview_csv_import'
+
   mount Riiif::Engine => 'images', as: :riiif if Hyrax.config.iiif_image_server?
   mount Blacklight::Engine => '/'
 

--- a/db/migrate/20190116214128_create_csv_imports.rb
+++ b/db/migrate/20190116214128_create_csv_imports.rb
@@ -1,0 +1,9 @@
+class CreateCsvImports < ActiveRecord::Migration[5.1]
+  def change
+    create_table :csv_imports do |t|
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190116220312_add_manifest_to_csv_imports.rb
+++ b/db/migrate/20190116220312_add_manifest_to_csv_imports.rb
@@ -1,0 +1,5 @@
+class AddManifestToCsvImports < ActiveRecord::Migration[5.1]
+  def change
+    add_column :csv_imports, :manifest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180604004616) do
+ActiveRecord::Schema.define(version: 20190116220312) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -68,6 +68,14 @@ ActiveRecord::Schema.define(version: 20180604004616) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "external_key"
+  end
+
+  create_table "csv_imports", force: :cascade do |t|
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "manifest"
+    t.index ["user_id"], name: "index_csv_imports_on_user_id"
   end
 
   create_table "curation_concerns_operations", force: :cascade do |t|
@@ -571,6 +579,7 @@ ActiveRecord::Schema.define(version: 20180604004616) do
   end
 
   add_foreign_key "collection_type_participants", "hyrax_collection_types"
+  add_foreign_key "csv_imports", "users"
   add_foreign_key "curation_concerns_operations", "users"
   add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", column: "conversation_id", name: "mb_opt_outs_on_conversations_id"
   add_foreign_key "mailboxer_notifications", "mailboxer_conversations", column: "conversation_id", name: "notifications_on_conversation_id"

--- a/spec/controllers/csv_imports_controller_spec.rb
+++ b/spec/controllers/csv_imports_controller_spec.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe CsvImportsController, type: :controller do
+  let(:admin_user) { FactoryBot.create(:admin) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:access_denied_message) { 'You are not authorized to access this page.' }
+
+  let(:csv_import) { CsvImport.create!(user: admin_user) }
+  let(:valid_attributes) { {} }
+
+  context 'not logged in' do
+    describe 'GET #index' do
+      before { get :index }
+
+      it 'denies access' do
+        expect(flash[:alert]).to eq access_denied_message
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    describe "GET #show" do
+      before { get :show, params: { id: csv_import.to_param } }
+
+      it 'denies access' do
+        expect(flash[:alert]).to eq access_denied_message
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    describe "GET #new" do
+      before { get :new }
+
+      it 'denies access' do
+        expect(flash[:alert]).to eq access_denied_message
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    describe "POST #preview" do
+      before { post :preview, params: { csv_import: valid_attributes } }
+
+      it 'denies access' do
+        expect(flash[:alert]).to eq access_denied_message
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    describe "POST #create" do
+      it 'denies access' do
+        post :create, params: { csv_import: valid_attributes }
+        expect(flash[:alert]).to eq access_denied_message
+        expect(response).to redirect_to(new_user_session_path)
+      end
+
+      it 'doesn\'t create a record' do
+        expect {
+          post :create, params: { csv_import: valid_attributes }
+        }.to change(CsvImport, :count).by(0)
+      end
+    end
+  end
+
+  context 'logged in as non-admin user' do
+    before { sign_in user }
+
+    describe 'GET #index' do
+      before { get :index }
+
+      it 'denies access' do
+        expect(flash[:alert]).to eq access_denied_message
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    describe "GET #show" do
+      before { get :show, params: { id: csv_import.to_param } }
+
+      it 'denies access' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    describe "GET #new" do
+      before { get :new }
+
+      it 'denies access' do
+        expect(flash[:alert]).to eq access_denied_message
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    describe "POST #preview" do
+      it 'denies access' do
+        post :preview, params: { csv_import: valid_attributes }
+        expect(flash[:alert]).to eq access_denied_message
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    describe "POST #create" do
+      it 'denies access' do
+        post :create, params: { csv_import: valid_attributes }
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'doesn\'t create a record' do
+        expect {
+          post :create, params: { csv_import: valid_attributes }
+        }.to change(CsvImport, :count).by(0)
+      end
+    end
+  end
+
+  context 'logged in admin user' do
+    before { sign_in admin_user }
+
+    describe 'GET #index' do
+      before { get :index }
+
+      it 'is successful' do
+        expect(response).to be_successful
+      end
+    end
+
+    describe "GET #show" do
+      before { get :show, params: { id: csv_import.to_param } }
+
+      it 'is successful' do
+        expect(response).to be_successful
+      end
+    end
+
+    describe "GET #new" do
+      before { get :new }
+
+      it 'is successful' do
+        expect(response).to be_successful
+      end
+    end
+
+    describe 'POST #preview' do
+      before { post :preview, params: { csv_import: valid_attributes } }
+
+      it 'displays the preview' do
+        expect(response).to be_successful
+      end
+    end
+
+    describe 'POST #create' do
+      context 'with valid params' do
+        it 'creates a new CsvImport' do
+          expect {
+            post :create, params: { csv_import: valid_attributes }
+          }.to change(CsvImport, :count).by(1)
+        end
+
+        it 'redirects to the show page for the newly created record' do
+          post :create, params: { csv_import: valid_attributes }
+          expect(response).to redirect_to(CsvImport.last)
+        end
+      end
+
+      context 'when there is an error' do
+        before do
+          allow_any_instance_of(CsvImport).to receive(:save).and_return(false)
+        end
+
+        it 'doesn\'t create a record' do
+          expect {
+            post :create, params: { csv_import: {} }
+          }.to change(CsvImport, :count).by(0)
+
+          expect(response).to be_successful # renders :new
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/csv_import/csv_files_with_problems/extra_headers.csv
+++ b/spec/fixtures/csv_import/csv_files_with_problems/extra_headers.csv
@@ -1,0 +1,4 @@
+another_header_1,another_header_2,title,files,representative_media,thumbnail,rendering,depositor,date_uploaded,date_modified,label,relative_path,import_url,resource_type,creator,contributor,description,keyword,license,rights_statement,publisher,date_created,subject,language,identifier,based_near,related_url,bibliographic_citation,source,visibility
+,,Work 1 Title,,,,,,,,,,,,,,,,,,,,,,,,,,,open
+,,Work 2 Title,,,,,,,,,,,,,,,,,,,,,,,,,,,open
+,,Work 3 Title,,,,,,,,,,,,,,,,,,,,,,,,,,,open

--- a/spec/fixtures/csv_import/csv_files_with_problems/missing_title_field.csv
+++ b/spec/fixtures/csv_import/csv_files_with_problems/missing_title_field.csv
@@ -1,0 +1,4 @@
+title,files,representative_media,thumbnail,rendering,depositor,date_uploaded,date_modified,label,relative_path,import_url,resource_type,creator,contributor,description,keyword,license,rights_statement,publisher,date_created,subject,language,identifier,based_near,related_url,bibliographic_citation,source,visibility
+Work 1 Title,,,,,,,,,,,,,,,,,,,,,,,,,,,open
+,,,,,,,,,,,,,,,,,,,,,,,,,,,open
+Work 3 Title,,,,,,,,,,,,,,,,,,,,,,,,,,,open

--- a/spec/fixtures/csv_import/csv_files_with_problems/missing_title_header.csv
+++ b/spec/fixtures/csv_import/csv_files_with_problems/missing_title_header.csv
@@ -1,0 +1,2 @@
+files,representative_media,thumbnail,rendering,depositor,date_uploaded,date_modified,label,relative_path,import_url,resource_type,creator,contributor,description,keyword,license,rights_statement,publisher,date_created,subject,language,identifier,based_near,related_url,bibliographic_citation,source,visibility
+,,,,,,,Work 1 label,,,,,,,,,,,,,,,,,,,open

--- a/spec/fixtures/csv_import/import_manifest.csv
+++ b/spec/fixtures/csv_import/import_manifest.csv
@@ -1,0 +1,4 @@
+title,files,representative_media,thumbnail,rendering,depositor,date_uploaded,date_modified,label,relative_path,import_url,resource_type,creator,contributor,description,keyword,license,rights_statement,publisher,date_created,subject,language,identifier,based_near,related_url,bibliographic_citation,source,visibility
+Work 1 Title,,,,,,,,,,,,,,,,,,,,,,,,,,,open
+Work 2 Title,,,,,,,,,,,,,,,,,,,,,,,,,,,open
+Work 3 Title,,,,,,,,,,,,,,,,,,,,,,,,,,,open

--- a/spec/models/csv_import_spec.rb
+++ b/spec/models/csv_import_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe CsvImport, type: :model do
+  subject(:csv_import) { described_class.new }
+
+  it 'has a CSV manifest' do
+    expect(csv_import.manifest).to be_a CsvManifestUploader
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -78,4 +78,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include Devise::Test::ControllerHelpers, type: :controller
 end

--- a/spec/routing/csv_imports_routing_spec.rb
+++ b/spec/routing/csv_imports_routing_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe CsvImportsController, type: :routing do
+  describe "routing" do
+    it "routes to #index" do
+      expect(get: "/csv_imports").to route_to("csv_imports#index")
+    end
+
+    it "routes to #new" do
+      expect(get: "/csv_imports/new").to route_to("csv_imports#new")
+    end
+
+    it "routes to #preview" do
+      expect(post: "/csv_imports/preview").to route_to("csv_imports#preview")
+    end
+
+    it "routes to #create" do
+      expect(post: "/csv_imports").to route_to("csv_imports#create")
+    end
+
+    it "routes to #show" do
+      expect(get: "/csv_imports/1").to route_to("csv_imports#show", id: "1")
+    end
+  end
+end

--- a/spec/uploaders/csv_manifest_uploader_spec.rb
+++ b/spec/uploaders/csv_manifest_uploader_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe CsvManifestUploader, type: :model do
+  let(:uploader) { csv_import.manifest }
+  let(:csv_import) do
+    import = CsvImport.new(user: user)
+    File.open(csv_file) { |f| import.manifest = f }
+    import
+  end
+  let(:user) { FactoryBot.build(:user) }
+
+  context 'a valid CSV file' do
+    let(:csv_file) { File.join(fixture_path, 'csv_import', 'import_manifest.csv') }
+
+    it 'has no errors' do
+      expect(uploader.errors).to eq []
+    end
+
+    it 'has no warnings' do
+      expect(uploader.warnings).to eq []
+    end
+  end
+
+  context 'a CSV that has warnings' do
+    let(:csv_file) { File.join(fixture_path, 'csv_import', 'csv_files_with_problems', 'extra_headers.csv') }
+
+    it 'has warning messages' do
+      expect(uploader.warnings).to eq [
+        'The field name "another_header_1" is not supported.  This field will be ignored, and the metadata for this field will not be imported.',
+        'The field name "another_header_2" is not supported.  This field will be ignored, and the metadata for this field will not be imported.'
+      ]
+    end
+  end
+
+  context 'a CSV that has errors' do
+    let(:csv_file) { File.join(fixture_path, 'csv_import', 'csv_files_with_problems', 'missing_title_header.csv') }
+
+    it 'has error messages' do
+      expect(uploader.errors).to eq ['Missing required column: "title".  Your spreadsheet must have this column.  If you already have this column, please check the spelling and capitalization.']
+    end
+  end
+end

--- a/spec/uploaders/csv_manifest_validator_spec.rb
+++ b/spec/uploaders/csv_manifest_validator_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe CsvManifestValidator, type: :model do
+  let(:validator) { described_class.new(manifest) }
+  let(:manifest) { csv_import.manifest }
+  let(:user) { FactoryBot.build(:user) }
+  let(:csv_import) do
+    import = CsvImport.new(user: user)
+    File.open(csv_file) { |f| import.manifest = f }
+    import
+  end
+
+  context 'a valid CSV file' do
+    let(:csv_file) { File.join(fixture_path, 'csv_import', 'import_manifest.csv') }
+
+    it 'has no errors' do
+      expect(validator.errors).to eq []
+    end
+
+    it 'has no warnings' do
+      expect(validator.warnings).to eq []
+    end
+
+    it 'returns the record count' do
+      validator.validate
+      expect(validator.record_count).to eq 3
+    end
+  end
+
+  context 'a file that can\'t be parsed' do
+    it 'has an error' do
+      skip # TODO
+    end
+  end
+
+  context 'a CSV that is missing required headers' do
+    let(:csv_file) { File.join(fixture_path, 'csv_import', 'csv_files_with_problems', 'missing_title_header.csv') }
+
+    it 'has an error' do
+      validator.validate
+      expect(validator.errors).to eq ['Missing required column: "title".  Your spreadsheet must have this column.  If you already have this column, please check the spelling and capitalization.']
+    end
+  end
+
+  context 'a CSV that is missing required fields' do
+    it 'has an error' do
+      skip # TODO
+    end
+  end
+
+  context 'a CSV that has extra headers' do
+    let(:csv_file) { File.join(fixture_path, 'csv_import', 'csv_files_with_problems', 'extra_headers.csv') }
+
+    it 'has a warning' do
+      validator.validate
+      expect(validator.warnings).to eq [
+        'The field name "another_header_1" is not supported.  This field will be ignored, and the metadata for this field will not be imported.',
+        'The field name "another_header_2" is not supported.  This field will be ignored, and the metadata for this field will not be imported.'
+      ]
+    end
+  end
+end


### PR DESCRIPTION
* Uses carrierwave gem (which is already a dependecy of Hyrax) to upload
and store the CSV manifest file.

* Uses environment variables to configure where the uploaded CSV files
will be stored, but the env vars are optional.  If not set, by default
it will use Hyrax's configured upload and cache directories.

* You must be logged in as an admin user to start a CSV-based import.

* When the user uploads a CSV file, we perform some basic validations on
the file and display a preview page that shows errors and warnings.

* After the user starts the import, the show page for a CsvImport will
display the current status of the import.  That is future work.  It
currently just has a placeholder in the show view.

* The index view for CsvImport records is just a placeholder fow now.
Fleshing out that page will be future work.

* I didn't add any navigation links to get to the new UI.  For now it's
a secret route.  We'll add menu links in a future PR.