### PR TITLE
Display collection name not ID

### DIFF
--- a/app/views/csv_imports/_collection_selection.html.erb
+++ b/app/views/csv_imports/_collection_selection.html.erb
@@ -1,3 +1,4 @@
 <div class="form-group">
-  <%= form.select :fedora_collection_id, options_for_select(Collection.all.map{ |c| [c.title.first.to_s, c.id] }), {}, class: "form-control", id: "fedora_collection_id"  %>
+  <% collections = ActiveFedora::SolrService.query('has_model_ssim:Collection') %>
+  <%= form.select :fedora_collection_id, options_for_select(collections.map{ |c| [c['title_tesim'], c['id']] }), {}, class: "form-control", id: "fedora_collection_id"  %>
 </div>

--- a/app/views/csv_imports/preview.html.erb
+++ b/app/views/csv_imports/preview.html.erb
@@ -10,7 +10,7 @@
           </div>
           <div class="col-md-4">
             <label> Collection: </label>
-            <%= @csv_import.fedora_collection_id %>
+            <%= ActiveFedora::SolrService.query("id:#{@csv_import.fedora_collection_id}")[0]['title_tesim'] %>
           </div>
         </div>
       <% end %>

--- a/app/views/csv_imports/show.html.erb
+++ b/app/views/csv_imports/show.html.erb
@@ -6,7 +6,7 @@
   <span> <%= File.basename(@csv_import.manifest.to_s) %> </span>
   <br />
   <label> Collection: </label>
-  <span> <%= @csv_import.fedora_collection_id %> </span>
+  <span>  <%=  ActiveFedora::SolrService.query("id:#{@csv_import.fedora_collection_id}")[0]['title_tesim'] %> </span>
   <br />
   <label> Uploaded by: </label>
   <span> <%= @csv_import.user.name %> </span>

--- a/spec/system/import_from_csv_spec.rb
+++ b/spec/system/import_from_csv_spec.rb
@@ -29,6 +29,9 @@ RSpec.describe 'Importing records from a CSV file', type: :system, js: true do
       # We expect to see warnings for this CSV file.
       expect(page).to have_content 'The field name "another_header_1" is not supported'
 
+      # We expect to see the title of the collection on the page
+      expect(page).to have_content 'Testing Collection'
+
       # There is a link so the user can cancel.
       expect(page).to have_link 'Cancel', href: new_csv_import_path(locale: I18n.locale)
 
@@ -39,6 +42,9 @@ RSpec.describe 'Importing records from a CSV file', type: :system, js: true do
       # The show page for the CsvImport
       expect(page).to have_content 'extra_headers.csv'
       expect(page).to have_content 'Start time'
+
+      # We expect to see the title of the collection on the page
+      expect(page).to have_content 'Testing Collection'
 
       # TODO: Check that the import got kicked off.
       # e.g. Check that a job got queued.


### PR DESCRIPTION
This commit changes the view so that the collection
name is displayed, not just the ID. It does this
with a Solr query so that it's not looking it up
in Fedora.

Connected to #84
Connected to #85