### PR TITLE
Add layout and basic UI to preview page

### DIFF
--- a/app/views/csv_imports/_collection_selection.html.erb
+++ b/app/views/csv_imports/_collection_selection.html.erb
@@ -1,4 +1,3 @@
-<label for="fedora-collection-id">Choose your collection: </label>
 <div class="form-group">
   <%= form.select :fedora_collection_id, options_for_select(Collection.all.map{ |c| [c.title.first.to_s, c.id] }), {}, class: "form-control", id: "fedora_collection_id"  %>
 </div>

--- a/app/views/csv_imports/_form.html.erb
+++ b/app/views/csv_imports/_form.html.erb
@@ -1,6 +1,33 @@
+<%= form_with(model: csv_import, local: true, html: { multipart: true }, url: preview_csv_import_path) do |form| %>
+  <div class="panel panel-default">
+    <div class="panel-body">
+      <div class="row">
+        <div class="col-md-4">
+          <div class="well well-lg">
+            <p> <b>Upload a CSV</b> that has your content. You can download a template to get started <a href="/import_manifest.csv">here</a>. </p>
+            <div class="text-center">
+              <%= render "file_upload", form: form  %>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-4">
+          <div class="well well-lg">
+            <p> <b>Choose a collection</b>. All imports need to be associated with a collection. </p>
+            <div class="text-center">
+              <%= render "collection_selection", form: form %>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-4">
+          <div class="well well-lg">
+            <p> <b>Preview your import</b> before starting the process. </p>
+            <div class="text-center">
+              <%= render "actions", form: form %>
+            </div>
+          </div>
+        </div>
+      </div>
 
-
-    <%= form_with(model: csv_import, local: true, html: { multipart: true }, url: preview_csv_import_path) do |form| %>
       <div class="row">
         <div class="col-md-4">
           <%= render "error", csv_import: csv_import %>
@@ -8,25 +35,7 @@
         <div class="col-md-4">
         </div>
       </div>
-      <div class="row">
 
-        <div class="col-md-4">
-          <%= render "file_upload", form: form  %>
-        </div>
-        <div class="col-md-8"></div>
-      </div>
 
       <%= form.hidden_field :manifest_cache %>
-      <div class="row">
-        <div class="col-md-2">
-          <%= render "collection_selection", form: form %>
-        </div>
-        <div class="col-md-8"></div>
-      </div>
-      <div class="row">
-        <div class="col-md-4">
-          <%= render "actions", form: form %>
-        </div>
-        <div class="cold-md-8"></div>
-      </div>
-    <% end %>
+<% end %>

--- a/app/views/csv_imports/_start_import_form.html.erb
+++ b/app/views/csv_imports/_start_import_form.html.erb
@@ -4,6 +4,6 @@
   <%= form.hidden_field :fedora_collection_id, value: csv_import.fedora_collection_id %>
 
   <div class="actions">
-    <%= form.submit 'Start Import' %>
+    <%= form.submit 'Start Import', class: 'btn btn-lg btn-primary' %>
   </div>
 <% end %>

--- a/app/views/csv_imports/new.html.erb
+++ b/app/views/csv_imports/new.html.erb
@@ -1,2 +1,2 @@
-<h2> Import a set of records </h2>
+<h2><span class="glyphicon glyphicon-cloud-upload"></span> Begin Your CSV Import </h2>
 <%= render 'form', csv_import: @csv_import %>

--- a/app/views/csv_imports/preview.html.erb
+++ b/app/views/csv_imports/preview.html.erb
@@ -1,45 +1,80 @@
-<h2> Preview of your CSV-based Import </h2>
+<h2><span class="glyphicon glyphicon-cloud-upload"></span>Preview your CSV Import</h2>
+<div class="panel panel-default">
+  <div class="panel-body">
+    <div id='csv_info'>
+      <% if @csv_import.manifest.file %>
+        <div class="row">
+          <div class="col-md-4">
+            <label> CSV Manifest: </label>
+            <%= File.basename(@csv_import.manifest.to_s) %>
+          </div>
+          <div class="col-md-4">
+            <label> Collection: </label>
+            <%= @csv_import.fedora_collection_id %>
+          </div>
+        </div>
+      <% end %>
 
-<div id='csv_info'>
-  <% if @csv_import.manifest.file %>
-    <label> CSV Manifest: </label>
-    <%= File.basename(@csv_import.manifest.to_s) %>
-    <label> Collection: </label>
-    <%= @csv_import.fedora_collection_id %>
-  <% end %>
-  <br />
+      <div class="row">
+        <div class="col-md-8">
+          <p> TODO: This import will add XXX new records. </p>
+        </div>
+      </div>
 
+      <% unless @csv_import.manifest_errors.empty? %>
+        <div class="row">
+          <div class="col-md-6">
+            <div class="alert alert-danger">
+              <div id='csv_errors'>
+                <b><i class="glyphicon glyphicon-remove-sign"></i> The CSV file has the following errors:</b>
+                <ul>
+                  <% @csv_import.manifest_errors.each do |error| %>
+                    <li> <%= error %> </li>
+                  <% end %>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
 
-  <p> TODO: This import will add XXX new records. </p>
+      <% unless @csv_import.manifest_warnings.empty? %>
+        <div class="row">
+          <div class="col-md-6">
+            <div class="alert alert-warning">
+              <div id='csv_warnings'>
+                <b><i class="glyphicon glyphicon-exclamation-sign"></i> The CSV file has the following warnings:</b>
+                <ul>
+                  <% @csv_import.manifest_warnings.each do |warning| %>
+                    <li> <%= warning %> </li>
+                  <% end %>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
+
+      <% if @csv_import.manifest_errors.empty? %>
+        <div class="row">
+          <div class="col-md-2">
+            <%= render 'start_import_form', csv_import: @csv_import, class: "btn btn-large btn-danger" %>
+          </div>
+          <div class="col-md-2">
+            <%= link_to 'Cancel', new_csv_import_path, class: "btn btn-lg btn-danger" %>
+          </div>
+        </div>
+      <% else %>
+        <div class="row">
+          <div class="col-md-4">
+            <div class="well"><p>You will need to correct the errors with the CSV file before you can continue.</p></br>
+              <div class="text-center"><%= link_to 'Try Again', new_csv_import_path, class: 'btn btn-lg btn-primary' %>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
 </div>
-
-<% unless @csv_import.manifest_errors.empty? %>
-  <div id='csv_errors'>
-    The CSV file has the following errors:
-    <ul>
-      <% @csv_import.manifest_errors.each do |error| %>
-        <li> <%= error %> </li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>
-
-<% unless @csv_import.manifest_warnings.empty? %>
-  <div id='csv_warnings'>
-    The CSV file has the following warnings:
-    <ul>
-      <% @csv_import.manifest_warnings.each do |warning| %>
-        <li> <%= warning %> </li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>
-
-<% if @csv_import.manifest_errors.empty? %>
-  <%= link_to 'Cancel', new_csv_import_path %>
-  <br />
-  <%= render 'start_import_form', csv_import: @csv_import %>
-<% else %>
-  <p> You will need to correct the errors with the CSV file before you can continue. </p>
-  <%= link_to 'Try Again', new_csv_import_path %>
-<% end %>
+</div>


### PR DESCRIPTION
This adds alert styling to the preview
page to make the warnings and errors
more distinct.

This adds basic bootstrap layouts to some
of the forms. We can rearrange these later
if need be, but this will get us some
layout building blocks that we can rearrange.

Connected to #87