### PR TITLE
Show the record count on the preview page

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ Metrics/BlockLength:
     - '**/*/catalog_controller.rb'
     - 'config/**/*'
     - 'spec/features**/*'
+    - 'spec/system**/*'
     - lib/tasks/tenejo.rake
     - 'spec/controllers/csv_imports_controller_spec.rb'
     - 'spec/uploaders/csv_manifest_validator_spec.rb'

--- a/app/models/csv_import.rb
+++ b/app/models/csv_import.rb
@@ -12,4 +12,8 @@ class CsvImport < ApplicationRecord
   def manifest_errors
     manifest.errors
   end
+
+  def manifest_records
+    manifest.records
+  end
 end

--- a/app/uploaders/csv_manifest_uploader.rb
+++ b/app/uploaders/csv_manifest_uploader.rb
@@ -33,6 +33,10 @@ class CsvManifestUploader < CarrierWave::Uploader::Base
     @validator ? @validator.warnings : []
   end
 
+  def records
+    @validator ? @validator.record_count : 0
+  end
+
   private
 
     def validate_csv

--- a/app/views/csv_imports/_record_count.html.erb
+++ b/app/views/csv_imports/_record_count.html.erb
@@ -1,0 +1,7 @@
+<div class="row">
+  <div class="col-md-8">
+    <div class="alert alert-success">
+      <p> This import will add <%= @csv_import.manifest_records %>  new records. </p>
+    </div>
+  </div>
+</div>

--- a/app/views/csv_imports/preview.html.erb
+++ b/app/views/csv_imports/preview.html.erb
@@ -1,4 +1,4 @@
-<h2><span class="glyphicon glyphicon-cloud-upload"></span>Preview your CSV Import</h2>
+<h2><span class="glyphicon glyphicon-cloud-upload"></span> Preview your CSV Import</h2>
 <div class="panel panel-default">
   <div class="panel-body">
     <div id='csv_info'>
@@ -15,11 +15,7 @@
         </div>
       <% end %>
 
-      <div class="row">
-        <div class="col-md-8">
-          <p> TODO: This import will add XXX new records. </p>
-        </div>
-      </div>
+      <%= render 'record_count', locals: { csv_import: @csv_import } %>
 
       <% unless @csv_import.manifest_errors.empty? %>
         <div class="row">

--- a/spec/system/import_from_csv_spec.rb
+++ b/spec/system/import_from_csv_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe 'Importing records from a CSV file', type: :system, js: true do
       # We expect to see the title of the collection on the page
       expect(page).to have_content 'Testing Collection'
 
+      expect(page).to have_content 'This import will add 3 new records.'
+
       # There is a link so the user can cancel.
       expect(page).to have_link 'Cancel', href: new_csv_import_path(locale: I18n.locale)
 

--- a/spec/uploaders/csv_manifest_uploader_spec.rb
+++ b/spec/uploaders/csv_manifest_uploader_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe CsvManifestUploader, type: :model do
     it 'has no warnings' do
       expect(uploader.warnings).to eq []
     end
+
+    it 'has a correct record count' do
+      expect(uploader.records).to eq 3
+    end
   end
 
   context 'a CSV that has warnings' do


### PR DESCRIPTION
This commit displays the number of records that
will be imported on the preview page.

Connected to #83