### PR TITLE
Styled the show page for CsvImport record.

### DIFF
--- a/app/views/csv_imports/show.html.erb
+++ b/app/views/csv_imports/show.html.erb
@@ -1,18 +1,31 @@
 <h2> Importing Records from a CSV File </h2>
 <p id="notice"><%= notice %></p>
 
-<p>
-  <label> CSV Manifest: </label>
-  <span> <%= File.basename(@csv_import.manifest.to_s) %> </span>
-  <br />
-  <label> Collection: </label>
-  <span>  <%=  ActiveFedora::SolrService.query("id:#{@csv_import.fedora_collection_id}")[0]['title_tesim'][0] %> </span>
-  <br />
-  <label> Uploaded by: </label>
-  <span> <%= @csv_import.user.name %> </span>
-  <br />
-  <label> Start time: </label>
-  <span> <%= @csv_import.created_at %> </span>
-</p>
+<div class="panel panel-default">
+  <div class="panel-body">
 
-<p> TODO: Put info about the current status of the import here. </p>
+    <p>
+    <label> CSV Manifest: </label>
+    <span> <%= File.basename(@csv_import.manifest.to_s) %> </span>
+    <br />
+    <label> Collection: </label>
+    <span>  <%=  ActiveFedora::SolrService.query("id:#{@csv_import.fedora_collection_id}")[0]['title_tesim'][0] %> </span>
+    <br />
+    <label> Uploaded by: </label>
+    <span> <%= @csv_import.user.name %> </span>
+    <br />
+    <label> Start time: </label>
+    <span> <%= @csv_import.created_at %> </span>
+    </p>
+
+    <div class="row">
+      <div class="col-md-6">
+        <div class='well'>
+          <p> Your records will be imported in the background.  To check the current status, please check the background job status page. </p><br />
+          <div class="text-center"> <%= link_to 'Background Job Status', sidekiq_web_path, class: "btn btn-primary btn-lg" %> </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>


### PR DESCRIPTION
* I added a link to the background job status page.  Until we get more
sophisticated reporting on the import status, this is the way to see if
the import is finished yet.

* I styled the page to look more like the preview page so user will
experience consistent style during the whole import process.

Connected to #101 

The page now looks like this:

<img width="941" alt="csv_import_show_page" src="https://user-images.githubusercontent.com/298865/52013798-9df72600-24a3-11e9-88d9-5db7062256b5.png">
