### PR TITLE
Add cron job via whenever to clean up /tmp

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -39,6 +39,9 @@ require 'capistrano/bundler'
 require 'capistrano/rails'
 require 'capistrano/sidekiq'
 require 'capistrano/passenger'
+require "whenever/capistrano"
+
+set :whenever_command, "bundle exec whenever"
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem 'jquery-rails'
 gem 'riiif', '~> 1.1'
 gem 'rsolr', '>= 1.0'
 gem 'sidekiq', '~> 5.1.3'
+gem 'whenever', require: false
 
 group :development do
   # Use Capistrano for deployment automation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,6 +180,7 @@ GEM
     chromedriver-helper (2.1.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    chronic (0.10.2)
     clipboard-rails (1.7.1)
     coderay (1.1.2)
     coffee-rails (4.2.2)
@@ -840,6 +841,8 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    whenever (0.10.0)
+      chronic (>= 0.6.3)
     xml-simple (1.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
@@ -891,6 +894,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  whenever
 
 RUBY VERSION
    ruby 2.5.1p57

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+# Delete blacklight saved searches
+every :day, at: '11:55pm' do
+  rake "blacklight:delete_old_searches[1]"
+end
+
+# Remove files in /tmp owned by the deploy user that are older than 7 days
+every :day, at: '1:00am' do
+  command "/usr/bin/find /tmp -type f -mtime +7 -user deploy -execdir /bin/rm -- {} \\;"
+end


### PR DESCRIPTION
This uses the same method as laevigata to cleanup
the `/tmp` directory. It doesn't remove files
from the upload directory.

It also empties the blacklight searches table nightly.

Connected to #117