### PR TITLE
Records imported by CSV importer should belong to logged-in user

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/curationexperts/darlingtonia.git
-  revision: dc8a9ac6961a8b24bfdb06301e4bd3a3d53c0aed
+  revision: 2eacd1f581b928bbb37507bc911d40839c1685ca
   branch: master
   specs:
     darlingtonia (2.0.0)

--- a/app/importers/modular_importer.rb
+++ b/app/importers/modular_importer.rb
@@ -2,16 +2,22 @@
 require 'darlingtonia'
 
 class ModularImporter
-  def initialize(csv_file, collection_id)
-    @csv_file = csv_file
-    @collection_id = collection_id
+  def initialize(csv_import)
+    @csv_file = csv_import.manifest.to_s
+    @collection_id = csv_import.fedora_collection_id
+    @user_id = csv_import.user_id
   end
 
   def import
     raise "Cannot find expected input file #{@csv_file}" unless File.exist?(@csv_file)
 
+    attrs = {
+      collection_id: @collection_id,
+      depositor_id: @user_id
+    }
+
     file = File.open(@csv_file)
-    Darlingtonia::Importer.new(parser: Darlingtonia::CsvParser.new(file: file), record_importer: Darlingtonia::HyraxRecordImporter.new(collection_id: @collection_id)).import
+    Darlingtonia::Importer.new(parser: Darlingtonia::CsvParser.new(file: file), record_importer: Darlingtonia::HyraxRecordImporter.new(attributes: attrs)).import
     file.close
   end
 end

--- a/app/jobs/start_csv_import_job.rb
+++ b/app/jobs/start_csv_import_job.rb
@@ -5,8 +5,7 @@ class StartCsvImportJob < ApplicationJob
 
   def perform(csv_import_id)
     csv_import = CsvImport.find csv_import_id
-    csv_file_path = csv_import.manifest.to_s
-    importer = ModularImporter.new(csv_file_path, csv_import.fedora_collection_id)
+    importer = ModularImporter.new(csv_import)
     importer.import
   end
 end

--- a/app/uploaders/csv_manifest_uploader.rb
+++ b/app/uploaders/csv_manifest_uploader.rb
@@ -45,10 +45,18 @@ class CsvManifestUploader < CarrierWave::Uploader::Base
     end
 
     def configured_upload_path
-      ENV['CSV_MANIFESTS_PATH'] || Hyrax.config.upload_path.call + 'csv_uploads'
+      ENV['CSV_MANIFESTS_PATH'] || base_path_uploads + 'csv_uploads'
     end
 
     def configured_cache_path
-      ENV['CSV_MANIFESTS_CACHE_PATH'] || Hyrax.config.cache_path.call + 'csv_uploads/cache'
+      ENV['CSV_MANIFESTS_CACHE_PATH'] || base_path_cache + 'csv_uploads/cache'
+    end
+
+    def base_path_uploads
+      ENV['TRAVIS'] ? Rails.root : Hyrax.config.upload_path.call
+    end
+
+    def base_path_cache
+      ENV['TRAVIS'] ? Rails.root : Hyrax.config.cache_path.call
     end
 end


### PR DESCRIPTION
Connected to #137

Note:  I made a change to the uploader to explicitly set the upload directory under the Rails root for the Travis build.  I'm not sure what changed since the last darlingtonia upgrade, or why this problem started happening now, but I was getting errors in the Travis build.  The errors were that uploaded files couldn't be found under `/tmp` (which I suspect we don't have permission to write to) instead of under the Rails root, even though the `UPLOAD_PATH` is set as a relative path.