### PR TITLE
Remove UPLOAD_PATH from test environment settings

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -7,6 +7,6 @@ GEONAMES_USERNAME=tenejodemo
 RAILS_SERVE_STATIC_FILES=true
 SIDEKIQ_WORKERS=5
 
-export UPLOAD_PATH=tmp/uploads
-export CACHE_PATH=tmp/uploads/cache
-export WORKING_PATH=tmp/uploads
+#export UPLOAD_PATH=tmp/uploads
+#export CACHE_PATH=tmp/uploads/cache
+#export WORKING_PATH=tmp/uploads


### PR DESCRIPTION
These are keeping tests from passing in my local environment now that we've updated how they're set.