### PR TITLE
Add logging

### DIFF
--- a/app/importers/modular_importer.rb
+++ b/app/importers/modular_importer.rb
@@ -2,10 +2,12 @@
 require 'darlingtonia'
 
 class ModularImporter
-  def initialize(csv_import)
+  def initialize(csv_import, log_stream:)
     @csv_file = csv_import.manifest.to_s
     @collection_id = csv_import.fedora_collection_id
     @user_id = csv_import.user_id
+    @user_email = User.find(csv_import.user_id).email
+    @log_stream = log_stream
   end
 
   def import
@@ -17,7 +19,16 @@ class ModularImporter
     }
 
     file = File.open(@csv_file)
+
+    Darlingtonia.config do |config|
+      config.default_error_stream = @log_stream
+      config.default_info_stream = @log_stream
+    end
+
+    @log_stream << "Import for collection: #{@collection_id} started by #{@user_email}"
+
     Darlingtonia::Importer.new(parser: Darlingtonia::CsvParser.new(file: file), record_importer: Darlingtonia::HyraxRecordImporter.new(attributes: attrs)).import
+
     file.close
   end
 end

--- a/app/jobs/start_csv_import_job.rb
+++ b/app/jobs/start_csv_import_job.rb
@@ -5,7 +5,9 @@ class StartCsvImportJob < ApplicationJob
 
   def perform(csv_import_id)
     csv_import = CsvImport.find csv_import_id
-    importer = ModularImporter.new(csv_import)
+    log_stream = Tenejo::LogStream.new
+    log_stream << "Starting import with batch ID: #{csv_import_id}"
+    importer = ModularImporter.new(csv_import, log_stream: log_stream)
     importer.import
   end
 end

--- a/app/lib/tenejo/log_stream.rb
+++ b/app/lib/tenejo/log_stream.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Tenejo
+  class LogStream
+    ##
+    # @!attribute [rw] logger
+    #   @return [Logger]
+    # @!attribute [rw] severity
+    #   @return [Logger::Serverity]
+    attr_accessor :logger, :severity
+
+    def initialize(logger: nil, severity: nil)
+      self.logger   = logger   || Logger.new(build_filename)
+      self.severity = severity || Logger::INFO
+    end
+
+    def <<(msg)
+      logger.add(severity, msg)
+    end
+
+    def build_filename
+      case Rails.env
+      when 'production'
+        Rails.root.join('log', "csv_import.log").to_s
+      when 'development'
+        Rails.root.join('log', "dev_csv_import.log").to_s
+      when 'test'
+        Rails.root.join('log', "test_csv_import.log").to_s
+      end
+    end
+  end
+end

--- a/spec/importers/modular_importer_spec.rb
+++ b/spec/importers/modular_importer_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe ModularImporter, :clean do
   let(:modular_csv) { 'spec/fixtures/csv_import/modular_input.csv' }
   let(:user) { ::User.batch_user }
   let(:collection) { FactoryBot.create(:collection) }
-
   let(:csv_import) do
     import = CsvImport.new(user: user, fedora_collection_id: collection.id)
     File.open(modular_csv) { |f| import.manifest = f }
     import
   end
+  let(:log_stream) { Tenejo::LogStream.new }
 
   before do
     ENV['IMPORT_PATH'] = File.expand_path('../fixtures/images', File.dirname(__FILE__))
@@ -21,7 +21,7 @@ RSpec.describe ModularImporter, :clean do
 
   it "imports a CSV with the correct metadata" do
     expect {
-      ModularImporter.new(csv_import).import
+      ModularImporter.new(csv_import, log_stream: log_stream).import
     }.to change { Work.count }.to 3
 
     work = Work.where(title: 'A Cute Dog').first
@@ -38,14 +38,20 @@ RSpec.describe ModularImporter, :clean do
 
   it "attaches files" do
     allow(AttachFilesToWorkJob).to receive(:perform_later)
-    ModularImporter.new(csv_import).import
+
+    ModularImporter.new(csv_import, log_stream: log_stream).import
     expect(AttachFilesToWorkJob).to have_received(:perform_later).exactly(3).times
   end
 
   it "adds the new record to the collection" do
     expect(Work.count).to eq 0
-    ModularImporter.new(csv_import).import
+    ModularImporter.new(csv_import, log_stream: log_stream).import
     work = Work.first
     expect(work.member_of_collections).to eq [collection]
+  end
+
+  it 'logs the collection and user id' do
+    ModularImporter.new(csv_import, log_stream: log_stream).import
+    expect(File.open("log/test_csv_import.log") { |f| f.readlines.join.match?("Import for collection: #{collection.id} started by #{user.email}") }).to eq(true)
   end
 end

--- a/spec/jobs/start_csv_import_job_spec.rb
+++ b/spec/jobs/start_csv_import_job_spec.rb
@@ -15,9 +15,10 @@ RSpec.describe StartCsvImportJob, perform_jobs: :true, type: :job do
 
       let(:csv_file) { File.join(fixture_path, 'csv_import', 'import_manifest.csv') }
 
-      it 'starts the importer' do
+      it 'starts the importer and logs the batch id' do
         expect_any_instance_of(ModularImporter).to receive(:import)
         described_class.perform_now(csv_import.id)
+        expect(File.open("log/test_csv_import.log") { |f| f.readlines.join.match?("Starting import with batch ID: #{csv_import.id}") }).to eq(true)
       end
     end
   end


### PR DESCRIPTION
This adds a `LogStream` class which is used by
darlingtonia to log imports. The log files
are located in log and are named differently
depending on what environment you are in.

The log file contains the record being imported,
the user depositing the record, the collection id,
and the batch ID. (These are all timestamped).

Connected to #143