### PR TITLE
Location import

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/curationexperts/darlingtonia.git
-  revision: 2eacd1f581b928bbb37507bc911d40839c1685ca
+  revision: ad46c5d8a50e9396f39f118aba3d7df2414353f1
   branch: master
   specs:
     darlingtonia (2.0.0)
@@ -199,7 +199,7 @@ GEM
     declarative-option (0.1.0)
     deprecation (1.0.0)
       activesupport
-    devise (4.5.0)
+    devise (4.6.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0, < 6.0)
@@ -215,7 +215,7 @@ GEM
     dropbox_api (0.1.12)
       faraday (~> 0.9, ~> 0.8)
       oauth2 (~> 1.1)
-    dry-configurable (0.8.0)
+    dry-configurable (0.8.1)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.4, >= 0.4.7)
     dry-container (0.7.0)
@@ -271,7 +271,7 @@ GEM
     execjs (2.7.0)
     factory_bot (5.0.0)
       activesupport (>= 4.2.0)
-    factory_bot_rails (5.0.0)
+    factory_bot_rails (5.0.1)
       factory_bot (~> 5.0.0)
       railties (>= 4.2.0)
     faraday (0.12.2)

--- a/spec/fixtures/csv_import/good/all_fields.csv
+++ b/spec/fixtures/csv_import/good/all_fields.csv
@@ -1,2 +1,2 @@
-keyword,rights_statement,creator,title,files
-Clothing stores $z California $z Los Angeles|~|Interior design $z California $z Los Angeles,copyrighted,"Connell, Will, $d 1898-1961","Interior view of The Bachelors haberdashery designed by Julius Ralph Davidson, Los Angeles, circa 1929",dog.jpg
+location,keyword,rights_statement,creator,title,files
+"http://www.geonames.org/5667009/montana.html|~|http://www.geonames.org/6252001/united-states.html",Clothing stores $z California $z Los Angeles|~|Interior design $z California $z Los Angeles,copyrighted,"Connell, Will, $d 1898-1961","Interior view of The Bachelors haberdashery designed by Julius Ralph Davidson, Los Angeles, circa 1929",dog.jpg

--- a/spec/fixtures/csv_import/good/all_fields.csv
+++ b/spec/fixtures/csv_import/good/all_fields.csv
@@ -1,0 +1,2 @@
+keyword,rights_statement,creator,title,files
+Clothing stores $z California $z Los Angeles|~|Interior design $z California $z Los Angeles,copyrighted,"Connell, Will, $d 1898-1961","Interior view of The Bachelors haberdashery designed by Julius Ralph Davidson, Los Angeles, circa 1929",dog.jpg

--- a/spec/fixtures/csv_import/modular_input.csv
+++ b/spec/fixtures/csv_import/modular_input.csv
@@ -1,4 +1,4 @@
 Title  ,Source,Visibility, Files,Rights Statement,Abstract or Summary,Date Created,Location,Related URL,Resource Type,Creator
-"A Cute Dog",https://www.pexels.com/photo/animal-blur-canine-close-up-551628/,open,dog.jpg,http://rightsstatements.org/vocab/InC/1.0/,dog photo|~|some kind of spaniel?,2018,United States,https://www.pexels.com/,image,Kat Jayne
+"A Cute Dog",https://www.pexels.com/photo/animal-blur-canine-close-up-551628/,open,dog.jpg,http://rightsstatements.org/vocab/InC/1.0/,dog photo|~|some kind of spaniel?,2018,http://www.geonames.org/6252001/united-states.html,https://www.pexels.com/,image,Kat Jayne
 "An Interesting Cat",https://www.pexels.com/photo/person-holding-white-cat-1383397/,open,cat.jpg|~|birds.jpg,http://rightsstatements.org/vocab/InC/1.0/,,,,,image,,
 "A Flock of Birds",https://www.pexels.com/photo/animal-avian-beak-birds-203088/,open,birds.jpg,http://rightsstatements.org/vocab/InC/1.0/,,,,,image,,

--- a/spec/importers/modular_importer_spec.rb
+++ b/spec/importers/modular_importer_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ModularImporter, :clean do
     expect(work.rights_statement).to eq ['http://rightsstatements.org/vocab/InC/1.0/']
     expect(work.description).to contain_exactly('dog photo', 'some kind of spaniel?')
     expect(work.date_created).to eq ['2018']
-    expect(work.based_near).to eq ['United States']
+    expect(work.based_near.first.class).to eq Hyrax::ControlledVocabularies::Location
     expect(work.related_url).to eq ['https://www.pexels.com/']
     expect(work.resource_type).to eq ['image']
     expect(work.creator).to eq ['Kat Jayne']

--- a/spec/system/import_from_csv_spec.rb
+++ b/spec/system/import_from_csv_spec.rb
@@ -2,8 +2,8 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.describe 'Importing records from a CSV file', type: :system, js: true do
-  let(:csv_file) { File.join(fixture_path, 'csv_import', 'csv_files_with_problems', 'extra - headers.csv') }
+RSpec.describe 'Importing records from a CSV file', :perform_jobs, type: :system, js: true do
+  let(:csv_file) { File.join(fixture_path, 'csv_import', 'good', 'all_fields.csv') }
 
   context 'logged in as an admin user' do
     let(:collection) { FactoryBot.build(:collection, title: ['Testing Collection']) }
@@ -22,16 +22,13 @@ RSpec.describe 'Importing records from a CSV file', type: :system, js: true do
 
       # Fill in and submit the form
       attach_file('csv_import[manifest]', csv_file, make_visible: true)
-      expect(page).to have_content 'extra_-_headers.csv'
+      expect(page).to have_content 'all_fields.csv'
       click_on 'Preview Import'
-
-      # We expect to see warnings for this CSV file.
-      expect(page).to have_content 'The field name "another_header_2" is not supported'
 
       # We expect to see the title of the collection on the page
       expect(page).to have_content 'Testing Collection'
 
-      expect(page).to have_content 'This import will add 3 new records.'
+      expect(page).to have_content 'This import will add 1 new records.'
 
       # There is a link so the user can cancel.
       expect(page).to have_link 'Cancel', href: new_csv_import_path(locale: I18n.locale)
@@ -41,15 +38,18 @@ RSpec.describe 'Importing records from a CSV file', type: :system, js: true do
       click_on 'Start Import'
 
       # The show page for the CsvImport
-      expect(page).to have_content 'extra_-_headers.csv'
+      expect(page).to have_content 'all_fields.csv'
       expect(page).to have_content 'Start time'
 
       # We expect to see the title of the collection on the page
       expect(page).to have_content 'Testing Collection'
 
-      # TODO: Check that the import got kicked off.
-      # e.g. Check that a job got queued.
-      # Or, let the background jobs run, and check that the expected number of records got created.
+      # Let the background jobs run, and check that the expected number of records got created.
+      expect(Work.count).to eq 1
+
+      # Ensure that all the fields got assigned as expected
+      work = Work.where(title: "*haberdashery*").first
+      expect(work.title.first).to match(/haberdashery/)
     end
   end
 end

--- a/spec/system/import_from_csv_with_warnings.rb
+++ b/spec/system/import_from_csv_with_warnings.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'Importing records from a CSV file', type: :system, js: true do
+  let(:csv_file) { File.join(fixture_path, 'csv_import', 'csv_files_with_problems', 'extra - headers.csv') }
+
+  context 'logged in as an admin user' do
+    let(:collection) { FactoryBot.build(:collection, title: ['Testing Collection']) }
+    let(:admin_user) { FactoryBot.create(:admin) }
+
+    before do
+      collection.save!
+      login_as admin_user
+    end
+
+    it 'starts the import' do
+      visit new_csv_import_path
+      expect(page).to have_content 'Testing Collection'
+      expect(page).not_to have_content '["Testing Collection"]'
+      select 'Testing Collection', from: "csv_import[fedora_collection_id]"
+
+      # Fill in and submit the form
+      attach_file('csv_import[manifest]', csv_file, make_visible: true)
+      expect(page).to have_content 'extra_-_headers.csv'
+      click_on 'Preview Import'
+
+      # We expect to see warnings for this CSV file.
+      expect(page).to have_content 'The field name "another_header_2" is not supported'
+
+      # We expect to see the title of the collection on the page
+      expect(page).to have_content 'Testing Collection'
+
+      expect(page).to have_content 'This import will add 3 new records.'
+
+      # There is a link so the user can cancel.
+      expect(page).to have_link 'Cancel', href: new_csv_import_path(locale: I18n.locale)
+
+      # After reading the warnings, the user decides
+      # to continue with the import.
+      click_on 'Start Import'
+
+      # The show page for the CsvImport
+      expect(page).to have_content 'extra_-_headers.csv'
+      expect(page).to have_content 'Start time'
+
+      # We expect to see the title of the collection on the page
+      expect(page).to have_content 'Testing Collection'
+    end
+  end
+end


### PR DESCRIPTION
The location field should accept urls of the form
http://www.geonames.org/6252001/united-states.html

As of the latest master branch of Darlingtonia, these are now
transformed into what Hyrax expects to see, where they will be
transformed into `Hyrax::ControlledVocabularies::Location` objects.

Connected to https://github.com/curationexperts/tenejo/issues/135