### PR TITLE
Add read-only mode

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,24 @@ class ApplicationController < ActionController::Base
   # Adds Hyrax behaviors into the application controller
   include Hyrax::Controller
   include Hyrax::ThemedLayoutController
+
+  # Check to see if we're in read_only mode
+  before_action :check_read_only, except: [:show, :index]
+
   with_themed_layout '1_column'
 
   protect_from_forgery with: :exception
+
+  # What to do if read_only mode has been enabled, via FlipFlop
+  # If read_only is enabled, redirect any requests that would allow
+  # changes to the system. This is to enable easier migrations.
+  def check_read_only
+    return unless Flipflop.read_only?
+    # Exempt the FlipFlop controller itself from read_only mode, so it can be turned off
+    return if self.class.to_s == Hyrax::Admin::StrategiesController.to_s
+    redirect_back(
+      fallback_location: root_path,
+      alert: "This system is in read-only mode for maintenance. No submissions or edits can be made at this time."
+    )
+  end
 end

--- a/config/features.rb
+++ b/config/features.rb
@@ -7,4 +7,8 @@ Flipflop.configure do
   feature :import_csv,
           default: true,
           description: "Allow the user to start a CSV import from the dashboard."
+
+  feature :read_only,
+          default: false,
+          description: "Put the system into read-only mode. Deposits, edits, approvals and anything that makes a change to the data will be disabled."
 end

--- a/spec/system/read_only_mode_spec.rb
+++ b/spec/system/read_only_mode_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+include Warden::Test::Helpers
+
+RSpec.describe 'Read Only Mode', type: :system do
+  let(:user) { create :user }
+
+  context 'a logged in user' do
+    before do
+      login_as user
+    end
+
+    scenario "Creating a work with read only mode enabled and disabled", js: false do
+      visit("/concern/works/new")
+      expect(page).to have_content("Add New Work")
+      allow(Flipflop).to receive(:read_only?).and_return(true)
+      visit("/concern/works/new")
+      expect(page).to have_content("This system is in read-only mode for maintenance.")
+      allow(Flipflop).to receive(:read_only?).and_return(false)
+      visit("/concern/works/new")
+      expect(page).to have_content("Add New Work")
+    end
+  end
+end


### PR DESCRIPTION
Add a FlipFlop feature toggle that puts
the system into read-only mode.
This will allow us to more easily migrate
data behind the scenes.

Add a rake task to put the repo in ready only mode.

Also, add sidekiq rake task. This lets us
control sidekiq more consistently, including
stopping and starting it gracefully.

Connected to #64