### PR TITLE
Mark virus spec as pending

### DIFF
--- a/spec/system/virus_scan_spec.rb
+++ b/spec/system/virus_scan_spec.rb
@@ -3,47 +3,49 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 RSpec.describe 'Virus Scanning', :clean, :js, :virus_scan, type: :system do
-  let(:admin) { FactoryBot.create(:admin) }
-  before { login_as admin }
-  after  { logout }
+  xit 'handles virus uploads correctly' do
+    let(:admin) { FactoryBot.create(:admin) }
+    before { login_as admin }
+    after  { logout }
 
-  let(:safe_path)  { "#{fixture_path}/images/cat.jpg" }
-  let(:virus_path) { "#{fixture_path}/virus_check.txt" }
+    let(:safe_path)  { "#{fixture_path}/images/cat.jpg" }
+    let(:virus_path) { "#{fixture_path}/virus_check.txt" }
 
-  scenario 'uploading a file with a virus', :perform_jobs do
-    ActiveJob::Base.queue_adapter.filter = [AttachFilesToWorkJob, IngestJob]
+    scenario 'uploading a file with a virus', :perform_jobs do
+      ActiveJob::Base.queue_adapter.filter = [AttachFilesToWorkJob, IngestJob]
 
-    visit('/concern/works/new')
-    click_link('Files')
+      visit('/concern/works/new')
+      click_link('Files')
 
-    within('#addfiles') do
-      attach_file('files[]', safe_path, visible: false, wait: 5)
-      attach_file('files[]', virus_path, visible: false, wait: 5)
+      within('#addfiles') do
+        attach_file('files[]', safe_path, visible: false, wait: 5)
+        attach_file('files[]', virus_path, visible: false, wait: 5)
+      end
+
+      click_link('Descriptions')
+      fill_in 'Title', with: 'A Work with a Virus'
+      fill_in 'Creator', with: 'Dmitri Ivanovsky'
+      fill_in 'Keyword', with: 'pathogens'
+      select('No Known Copyright', from: 'Rights')
+
+      allow(Rails.logger).to receive(:error)
+
+      find(:css, '#agreement').set(true)
+      click_on('Save')
+
+      visit('/dashboard/my/works')
+      click_link('A Work with a Virus')
+
+      expect(Rails.logger)
+        .to have_received(:error)
+        .with(/Virus.*virus_check\.txt/m)
+
+      # does not attach the virus file; deletes it from disk
+      expect(Hyrax::UploadedFile.select { |f| f.file.file.exists? }.count).to eq 1
+
+      # Check that a notification is created
+      find(:css, '.notify-number').click
+      expect(page).to have_content('virus')
     end
-
-    click_link('Descriptions')
-    fill_in 'Title', with: 'A Work with a Virus'
-    fill_in 'Creator', with: 'Dmitri Ivanovsky'
-    fill_in 'Keyword', with: 'pathogens'
-    select('No Known Copyright', from: 'Rights')
-
-    allow(Rails.logger).to receive(:error)
-
-    find(:css, '#agreement').set(true)
-    click_on('Save')
-
-    visit('/dashboard/my/works')
-    click_link('A Work with a Virus')
-
-    expect(Rails.logger)
-      .to have_received(:error)
-      .with(/Virus.*virus_check\.txt/m)
-
-    # does not attach the virus file; deletes it from disk
-    expect(Hyrax::UploadedFile.select { |f| f.file.file.exists? }.count).to eq 1
-
-    # Check that a notification is created
-    find(:css, '.notify-number').click
-    expect(page).to have_content('virus')
   end
 end


### PR DESCRIPTION
This spec is causing intermittent failures. This
will skip it for now until we have some time to
go back and make the spec more reliable.

It is failing because capybara clicks through the
interface faster than the object can be created
in Fedora. It will be difficult to get that timing
solid.

Connected to #165