### PR TITLE
Require valid license values

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,9 @@ Metrics/BlockLength:
     - spec/importers/modular_importer_spec.rb
     - spec/rails_helper.rb
 
+Metrics/MethodLength:
+  Enabled: false
+
 RSpec/AnyInstance:
   Enabled: false
 

--- a/app/lib/attach_files_to_work_job.rb
+++ b/app/lib/attach_files_to_work_job.rb
@@ -9,7 +9,6 @@ class AttachFilesToWorkJob < Hyrax::ApplicationJob
 
   # @param [ActiveFedora::Base] work - the work object
   # @param [Array<Hyrax::UploadedFile>] uploaded_files - an array of files to attach
-  # rubocop:disable Metrics/MethodLength
   def perform(work, uploaded_files, **work_attributes)
     validate_files!(uploaded_files)
     depositor = proxy_or_depositor(work)

--- a/spec/fixtures/csv_import/errors/invalid_license.csv
+++ b/spec/fixtures/csv_import/errors/invalid_license.csv
@@ -1,0 +1,2 @@
+license,visibility,location,keyword,rights_statement,creator,title,files
+http://creativecommons.org/licenses/foobar,PUBlic,"http://www.geonames.org/5667009/montana.html|~|http://www.geonames.org/6252001/united-states.html",Clothing stores $z California $z Los Angeles|~|Interior design $z California $z Los Angeles,copyrighted,"Connell, Will, $d 1898-1961","Interior view of The Bachelors haberdashery designed by Julius Ralph Davidson, Los Angeles, circa 1929",dog.jpg

--- a/spec/fixtures/csv_import/good/all_fields.csv
+++ b/spec/fixtures/csv_import/good/all_fields.csv
@@ -1,2 +1,2 @@
-visibility,location,keyword,rights_statement,creator,title,files
-PUBlic,"http://www.geonames.org/5667009/montana.html|~|http://www.geonames.org/6252001/united-states.html",Clothing stores $z California $z Los Angeles|~|Interior design $z California $z Los Angeles,copyrighted,"Connell, Will, $d 1898-1961","Interior view of The Bachelors haberdashery designed by Julius Ralph Davidson, Los Angeles, circa 1929",dog.jpg
+license,visibility,location,keyword,rights_statement,creator,title,files
+http://creativecommons.org/licenses/by/3.0/us/,PUBlic,"http://www.geonames.org/5667009/montana.html|~|http://www.geonames.org/6252001/united-states.html",Clothing stores $z California $z Los Angeles|~|Interior design $z California $z Los Angeles,copyrighted,"Connell, Will, $d 1898-1961","Interior view of The Bachelors haberdashery designed by Julius Ralph Davidson, Los Angeles, circa 1929",dog.jpg

--- a/spec/system/import_from_csv_spec.rb
+++ b/spec/system/import_from_csv_spec.rb
@@ -66,6 +66,9 @@ RSpec.describe 'Importing records from a CSV file', :perform_jobs, :clean, type:
       # Controlled vocabulary location should have been resolved to its label name
       expect(page).to have_content "Montana"
       expect(page).to have_content "United States"
+
+      # The license value resolves to a controlled field from creative commons
+      expect(page).to have_link "Attribution 3.0 United States"
     end
   end
 end

--- a/spec/uploaders/csv_manifest_validator_spec.rb
+++ b/spec/uploaders/csv_manifest_validator_spec.rb
@@ -89,4 +89,15 @@ RSpec.describe CsvManifestValidator, type: :model do
       ]
     end
   end
+
+  context 'a CSV that has invalid license values' do
+    let(:csv_file) { File.join(fixture_path, 'csv_import', 'errors', 'invalid_license.csv') }
+
+    it 'has an error' do
+      validator.validate
+      expect(validator.errors).to eq [
+        "Invalid license value in row 1: http://creativecommons.org/licenses/foobar"
+      ]
+    end
+  end
 end


### PR DESCRIPTION
Invalid license values result in an application error, so ensure we only
have valid license values before we import the CSV.

Connected to https://github.com/curationexperts/tenejo/issues/172