### PR TITLE
Remove the footer from dashboard but show version info

### DIFF
--- a/app/views/layouts/hyrax/dashboard.html.erb
+++ b/app/views/layouts/hyrax/dashboard.html.erb
@@ -26,13 +26,13 @@
           </div>
         <% end %>
 
-          <a name="skip-to-content" id="skip-to-content"></a>
-          <%= content_for?(:content) ? yield(:content) : yield %>
-
+        <a name="skip-to-content" id="skip-to-content"></a>
+        <%= content_for?(:content) ? yield(:content) : yield %>
+        <%= render 'shared/footer_content' %>
       </div>
 
+
     </div><!-- /#content-wrapper -->
-    <%= render 'shared/footer' %>
     <%= render 'shared/ajax_modal' %>
   </body>
 </html>

--- a/app/views/shared/_footer_content.html.erb
+++ b/app/views/shared/_footer_content.html.erb
@@ -1,8 +1,8 @@
-<footer class="navbar navbar-inverse">
-<div class="container-fluid">
+<div id="content-wrapper" role="main">
+  <div class="container-fluid">
     <div class="navbar-text text-left">
-        <p><%= t('hyrax.footer.service_html') %></p>
-        <p><%= t('hyrax.product_name') %> v<%= Hyrax::VERSION %></p>
+      <p><%= t('hyrax.footer.service_html') %></p>
+      <p><%= t('hyrax.product_name') %> v<%= Hyrax::VERSION %></p>
     </div>
     <div class="navbar-right">
       <div class="navbar-text text-right">
@@ -11,4 +11,4 @@
       </div>
     </div>
   </div>
-</footer>
+</div>

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 require 'rails_helper'
 include Warden::Test::Helpers
@@ -17,6 +18,10 @@ RSpec.describe 'Dashboard', type: :system do
 
     it 'can get to the importer page' do
       expect(page).to have_link 'Import Content From a CSV'
+    end
+
+    it 'has the footer version' do
+      expect(page).to have_content ENV['DEPLOYED_VERSION']
     end
   end
 end


### PR DESCRIPTION
This removes the footer, but re-displays the
information from the footer in the larger content area
of the dashboard.

Connected to #144