### PR TITLE
Override index list view

### DIFF
--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -1,0 +1,26 @@
+<div class="col-md-6">
+  <div class="metadata">
+    <dl class="dl-horizontal">
+    <% doc_presenter = index_presenter(document) %>
+    <% index_fields(document).each do |field_name, field| -%>
+      <% if should_render_index_field? document, field %>
+          <dt><%= render_index_field_label document, field: field_name %></dt>
+          <dd><%= doc_presenter.field_value field %></dd>
+      <% end %>
+    <% end %>
+    </dl>
+  </div>
+</div>
+<% if document.collection? %>
+<% collection_presenter = Hyrax::CollectionPresenter.new(document, current_ability) %>
+<div class="col-md-4">
+  <div class="collection-counts-wrapper">
+    <div class="collection-counts-item">
+      <span><%= collection_presenter.total_viewable_collections %></span>Collections
+    </div>
+    <div class="collection-counts-item">
+      <span><%= collection_presenter.total_viewable_works %></span>Works
+    </div>
+  </div>
+</div>
+<% end %>


### PR DESCRIPTION
This overrides the index list view
to avoid a deprecation notice appearing
in the logs.

Connected to curationexperts/tenejo#214