### PR TITLE
Disable contact form

### DIFF
--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -1,0 +1,17 @@
+<nav class="navbar navbar-default navbar-static-top" role="navigation">
+  <div class="container-fluid">
+    <div class="row">
+      <ul class="nav navbar-nav col-sm-5">
+        <li <%= 'class=active' if current_page?(hyrax.root_path) %>>
+          <%= link_to t(:'hyrax.controls.home'), hyrax.root_path, aria: current_page?(hyrax.root_path) ? {current: 'page'} : nil %></li>
+        <li <%= 'class=active' if current_page?(hyrax.about_path) %>>
+          <%= link_to t(:'hyrax.controls.about'), hyrax.about_path, aria: current_page?(hyrax.about_path) ? {current: 'page'} : nil %></li>
+        <li <%= 'class=active' if current_page?(hyrax.help_path) %>>
+          <%= link_to t(:'hyrax.controls.help'), hyrax.help_path, aria: current_page?(hyrax.help_path) ? {current: 'page'} : nil %></li>
+      </ul><!-- /.nav -->
+      <div class="searchbar-right navbar-right col-sm-7">
+        <%= render partial: 'catalog/search_form' %>
+      </div>
+    </div>
+  </div>
+</nav><!-- /.navbar -->

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require_relative 'boot'
 require_relative 'exception_middleware'
+require_relative 'contact_redirect_middleware'
 
 require 'rails/all'
 
@@ -15,5 +16,6 @@ module Tenejo
 
     config.active_job.queue_adapter = :sidekiq
     config.middleware.use(::ExceptionMiddleware)
+    config.middleware.use(::ContactRedirectMiddleware)
   end
 end

--- a/config/contact_redirect_middleware.rb
+++ b/config/contact_redirect_middleware.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class ContactRedirectMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    request = Rack::Request.new(env)
+    if request.path.include?('/contact')
+      [301, { 'Location' => '/not-found', 'Content-Type' => 'text/html' }, ['Moved Permanently']]
+    else
+      @app.call(env)
+    end
+  end
+end

--- a/spec/system/contact_form_spec.rb
+++ b/spec/system/contact_form_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'Not having a contact form', type: :system do
+  context 'visiting the contact form directly' do
+    it 'has a 404 page' do
+      visit('/contact')
+      expect(page).to have_content('does not exist')
+    end
+  end
+
+  context 'in the navbar' do
+    it 'does not have a link' do
+      visit('/')
+      expect(page).not_to have_link('Contact')
+    end
+  end
+end


### PR DESCRIPTION
This disables the contact form. Right now
it is not submitting because email has not been
setup. If email is turned on there isn't a captcha
to prevent this from being used for spam and there are
500+ attempts to use the contact form in Honeybadger.

Because these routes come from an Engine you can't just put
an override in `routes.rb` which is why I did it
this way.

This removes the link to the contact form and redirects you
to a `404` if you try to access it directly.

Fixes curationexperts/tenejo#230