### PR TITLE
Add email config

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -29,3 +29,8 @@ WORKING_PATH=tmp/uploads
 IMPORT_PATH=/path/to/your/images
 
 GA_TRACKING_CODE=UA-not-a-real-code-1
+
+SMTP_ADDRESS=smtp.example.com
+SMTP_PORT=587
+SMTP_USERNAME=someone
+SMTP_PASSWORD=something

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,7 +61,7 @@ Rails.application.configure do
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "tenjeo_#{Rails.env}"
-  #config.action_mailer.perform_caching = false
+  # config.action_mailer.perform_caching = false
 
   config.action_mailer.perform_deliveries = true
   config.action_mailer.delivery_method = :smtp

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,7 +61,17 @@ Rails.application.configure do
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "tenjeo_#{Rails.env}"
-  config.action_mailer.perform_caching = false
+  #config.action_mailer.perform_caching = false
+
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: ENV['SMTP_ADDRESS'],
+    port: ENV['SMTP_PORT'],
+    user_name: ENV['SMTP_USERNAME'],
+    password: ENV['SMTP_PASSWORD'],
+    enable_starttls_auto: true
+  }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
This adds the config block for smtp email
delivery to the prod env. The credentials
need to be set using the env variables in
the sample & config.