### PR TITLE
Redirect ActiveFedora::ObjectNotFoundError to 404

### DIFF
--- a/config/exception_middleware.rb
+++ b/config/exception_middleware.rb
@@ -10,5 +10,8 @@ class ExceptionMiddleware
   rescue Blacklight::Exceptions::RecordNotFound
     # Redirect to non-existant location, which goes to the 404 page
     [301, { 'Location' => '/not-found', 'Content-Type' => 'text/html' }, ['Moved Permanently']]
+  rescue ActiveFedora::ObjectNotFoundError
+    # Redirect to non-existant location, which goes to the 404 page
+    [301, { 'Location' => '/not-found', 'Content-Type' => 'text/html' }, ['Moved Permanently']]
   end
 end

--- a/spec/system/404_spec.rb
+++ b/spec/system/404_spec.rb
@@ -18,4 +18,11 @@ RSpec.describe 'Getting a 404 for RecordNotFound', type: :system do
       expect(page).to have_content('does not exist')
     end
   end
+
+  context 'visiting a non-existent collection' do
+    it 'has a 404 page' do
+      visit('/collections/not_a_collection_id')
+      expect(page).to have_content('does not exist')
+    end
+  end
 end


### PR DESCRIPTION
This will stop the application from generating an error every time
someone hits an invalid object ID.

Connected to https://github.com/curationexperts/tenejo/issues/232