### PR TITLE
Use Fedora 4.7.5 in development

### DIFF
--- a/.fcrepo_wrapper
+++ b/.fcrepo_wrapper
@@ -1,4 +1,5 @@
 # Place any default configuration for solr_wrapper here
 port: 8984
+version: 4.7.5
 enable_jms: false
 fcrepo_home_dir: tmp/fcrepo4-development-data

--- a/config/fcrepo_wrapper_test.yml
+++ b/config/fcrepo_wrapper_test.yml
@@ -1,5 +1,6 @@
 #config/fcrepo_wrapper_test.yml.sample
 port: 8986
+version: 4.7.5
 enable_jms: false
 fcrepo_home_dir: tmp/fcrepo4-test-data
 download_dir: tmp/fedora_downloads


### PR DESCRIPTION
We're using 4.7.5 in production, so let's match that in test and
development.