### PR TITLE
Add Hyrda Role Management UI

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -20,5 +20,7 @@ class Ability
     # end
 
     can :manage, CsvImport if current_user.admin?
+
+    can [:create, :show, :add_user, :remove_user, :index, :edit, :update, :destroy], Role if current_user.admin?
   end
 end

--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -7,7 +7,13 @@
 
   <% if current_user.admin? %>
     <%= menu.nav_link(hyrax.admin_users_path) do %>
-        <span class="fa fa-user"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.users') %></span>
+      <span class="fa fa-user"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.users') %></span>
+    <% end %>
+  <% end %>
+
+  <% if current_user.admin? %>
+    <%= menu.nav_link('/roles/') do %>
+      <span class="fa fa-id-card"></span> <span class="sidebar-action-text">Manage User Roles</span>
     <% end %>
   <% end %>
 

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -23,5 +23,21 @@ RSpec.describe 'Dashboard', type: :system do
     it 'has the footer version' do
       expect(page).to have_content ENV['DEPLOYED_VERSION']
     end
+
+    it 'does not have a link to the user roles page' do
+      expect(page).not_to have_link 'Manage User Roles'
+    end
+  end
+
+  context 'as an admin user' do
+    let(:admin) { FactoryBot.create(:admin) }
+    before do
+      login_as admin
+      visit '/dashboard'
+    end
+
+    it 'has a link to the user roles page' do
+      expect(page).to have_link 'Manage User Roles'
+    end
   end
 end

--- a/spec/system/role_management_spec.rb
+++ b/spec/system/role_management_spec.rb
@@ -1,0 +1,37 @@
+# coding: utf-8
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'Dashboard', type: :system do
+  context 'as a regular user' do
+    let(:user) { FactoryBot.create(:user) }
+
+    before do
+      login_as user
+    end
+
+    it 'the role management page is not accessible' do
+      visit('/roles')
+      expect(page).to have_content 'not authorized'
+    end
+  end
+
+  context 'as an admin user' do
+    let(:admin) { FactoryBot.create(:admin) }
+    let(:user) { FactoryBot.create(:user) }
+
+    before do
+      login_as admin
+    end
+
+    it 'lets you manage roles' do
+      visit('/roles')
+      expect(page).to have_content('Roles')
+      click_on 'admin'
+      fill_in 'User', with: user.email
+      click_on 'Add'
+      expect(page).to have_content user.email
+    end
+  end
+end


### PR DESCRIPTION
There is a UI for this but it needs to be
configured in the `Ability` class.

There are no links to the UI so one needs
to be added to the dashboard.

Connected to curationexperts/tenejo#243