### PR TITLE
Add optional docker-compose setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ tramp
 .\#*
 public/tmp
 darlingtonia_import.log
+
+# Ignore bundle folder that can be created by docker-compose
+./bundle
+bundle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+FROM ruby:2.5-stretch
+
+RUN apt-get update -qq
+# Add https support to apt to download yarn & node
+RUN apt install -y apt-transport-https
+
+# Add basic dev tools
+RUN apt install -y curl build-essential wget git
+
+# Add node and yarn repos and install them along
+# along with other rails deps
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update -qq
+
+# Install system dependencies
+RUN apt-get update -qq && apt install -y --no-install-recommends postgresql-client build-essential libpq-dev nodejs yarn imagemagick libreoffice ffmpeg unzip clamav clamav-freshclam clamav-daemon openjdk-8-jre-headless
+
+# Chrome 74
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list
+RUN apt-get update && apt-get -y install google-chrome-stable
+
+# Chromedriver
+RUN wget -q https://chromedriver.storage.googleapis.com/74.0.3729.6/chromedriver_linux64.zip
+RUN unzip chromedriver_linux64.zip -d /usr/local/bin
+RUN rm -f chromedriver_linux64.zip
+
+# Install Ruby Gems
+RUN gem install bundler
+ENV BUNDLE_PATH /usr/local/bundle
+WORKDIR /tenejo
+COPY Gemfile /tenejo/Gemfile
+COPY Gemfile.lock /tenejo/Gemfile.lock
+RUN bundle install
+
+# Update AV
+RUN freshclam
+RUN /etc/init.d/clamav-daemon start &
+
+# Install fits
+RUN mkdir /fits
+WORKDIR /fits
+ADD https://github.com/harvard-lts/fits/releases/download/1.4.0/fits-1.4.0.zip /fits/
+RUN unzip fits-1.4.0.zip -d /fits
+ENV PATH "/fits:$PATH"
+
+# Add tenejo
+COPY / /tenejo
+CMD ["sh", "/tenejo/docker/start-app.sh"]

--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,6 @@ group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '~> 2.13'
-  gem 'chromedriver-helper'
   gem 'factory_bot_rails'
   gem 'fcrepo_wrapper'
   gem 'ffaker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,8 +64,6 @@ GEM
       sshkit (>= 1.6.1, != 1.7.0)
     almond-rails (0.1.0)
       rails (>= 4.2, < 6)
-    archive-zip (0.12.0)
-      io-like (~> 0.3.0)
     arel (8.0.0)
     ast (2.4.0)
     autoprefixer-rails (9.6.1)
@@ -171,9 +169,6 @@ GEM
       mime-types (>= 1.16)
     childprocess (1.0.1)
       rake (< 13.0)
-    chromedriver-helper (2.1.1)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     chronic (0.10.2)
     clamby (1.6.2)
     clipboard-rails (1.7.1)
@@ -411,7 +406,6 @@ GEM
     ice_nine (0.11.2)
     iiif_manifest (0.5.0)
       activesupport (>= 4)
-    io-like (0.3.0)
     jaro_winkler (1.5.3)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
@@ -856,7 +850,6 @@ DEPENDENCIES
   capistrano-rails
   capistrano-sidekiq (~> 0.20.0)
   capybara (~> 2.13)
-  chromedriver-helper
   clamby
   coffee-rails (~> 4.2)
   devise

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,4 +1,6 @@
 default: &default
+  host: <%= ENV['DATABASE_HOST'] || '127.0.0.1' %>
+  username: <%= ENV['CI'] == 'true' ? ('travis') : (ENV['POSTGRES_USER'] || 'tenejo') %>
   adapter:  postgresql
   encoding: unicode
   pool:     <%= ENV['DATABASE_POOL_SIZE'] || 5 %>

--- a/config/fedora.yml
+++ b/config/fedora.yml
@@ -1,12 +1,12 @@
 development:
   user: fedoraAdmin
   password: fedoraAdmin
-  url: http://127.0.0.1:<%= ENV['FCREPO_DEVELOPMENT_PORT'] || 8984 %>/rest
+  url: <%= ENV['FEDORA_DEV_URL'] || "http://127.0.0.1:#{ENV['FCREPO_DEVELOPMENT_PORT'] || 8984}/rest" %>
   base_path: /dev
 test:
   user: fedoraAdmin
   password: fedoraAdmin
-  url: http://127.0.0.1:<%= ENV['FCREPO_TEST_PORT'] || 8986 %>/rest
+  url: <%= ENV['FEDORA_TEST_URL'] || "http://127.0.0.1:#{ENV['FCREPO_TEST_PORT'] || 8986}/rest" %>
   base_path: /test
 production:
   user: fedoraAdmin

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,9 +1,9 @@
 development:
-  host: localhost
+  host: <% ENV['REDIS_HOST'] || 'localhost' %>
   port: 6379
 test:
-  host: localhost
+  host: <% ENV['REDIS_HOST'] || 'localhost' %>
   port: 6379
 production:
-  host: localhost
+  host: <% ENV['REDIS_HOST'] || 'localhost' %>
   port: 6379

--- a/config/solr.yml
+++ b/config/solr.yml
@@ -1,7 +1,7 @@
 # This is a sample config file that points to a solr server for each environment
 development:
-  url: http://127.0.0.1:<%= ENV['SOLR_TEST_PORT'] || 8983 %>/solr/hydra-development
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV['SOLR_TEST_PORT'] || 8983}/solr/hydra-development" %>
 test:
-  url: http://127.0.0.1:<%= ENV['SOLR_TEST_PORT'] || 8985 %>/solr/hydra-test
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV['SOLR_TEST_PORT'] || 8985}/solr/hydra-test" %>
 production:
   url: http://127.0.0.1:8983/solr/tenejo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,141 @@
+version: "3.6"
+
+services:
+  web:
+    image: curationexperts/tenejo:latest
+    depends_on:
+      - db
+      - fedora
+      - redis
+      - solr
+      - fedora_test
+      - solr_test
+    env_file:
+      - ./.env.sample
+    environment:
+      DATABASE_HOST: db
+      FEDORA_HOST: http://fedora
+      FEDORA_PORT: 8080
+      FEDORA_DEV_URL: http://fedora:8080/rest
+      FEDORA_BASE_PATH: /dev
+      FEDORA_TEST_URL: http://fedora_test:8080/rest
+      FEDORA_TEST_BASE_PATH: /test
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_URL: redis://redis:6379/0
+      SOLR_URL: http://solr:8983/solr/tenejo
+      SOLR_TEST_URL: http://solr_test:8983/solr/tenejo
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/tenejo
+      - data:/opt/data
+      - derivatives:/opt/derivatives
+      - uploads:/opt/uploads
+      - ./bundle:/usr/local/bundle
+      - log:/tenejo/log
+      - tenejo_tmp:/tenejo/tmp
+      - tmp:/tmp
+    working_dir: /tenejo
+    stdin_open: true
+    tty: true
+  sidekiq:
+    image: curationexperts/tenejo:latest
+    command: ['bundle', 'exec', 'sidekiq']
+    depends_on:
+      - web
+      - db
+      - fedora
+      - redis
+      - solr
+      - fedora_test
+      - solr_test
+    env_file:
+      - ./.env.sample
+    environment:
+      DATABASE_HOST: db
+      FEDORA_HOST: http://fedora
+      FEDORA_PORT: 8080
+      FEDORA_DEV_URL: http://fedora:8080/rest
+      FEDORA_BASE_PATH: /dev
+      FEDORA_TEST_URL: http://fedora_test:8080/rest
+      FEDORA_TEST_BASE_PATH: /test
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_URL: redis://redis:6379/0
+      SOLR_URL: http://solr:8983/solr/tenejo
+      SOLR_TEST_URL: http://solr_test:8983/solr/tenejo
+    volumes:
+      - .:/tenejo
+      - data:/opt/data
+      - derivatives:/opt/derivatives
+      - uploads:/opt/uploads
+      - ./bundle:/usr/local/bundle
+      - log:/tenejo/log
+      - tenejo_tmp:/tenejo/tmp
+      - tmp:/tmp
+    working_dir: /tenejo
+  fedora:
+    image: nulib/fcrepo4:4.7.5
+    ports:
+      - "8984:8080"
+    volumes:
+      - fcrepo_data:/data
+    environment:
+      JAVA_OPTIONS: "-Xmx512m"
+    stdin_open: true
+    tty: true
+  fedora_test:
+    image: nulib/fcrepo4:4.7.5
+    ports:
+      - "8986:8080"
+    environment:
+      JAVA_OPTIONS: "-Xmx512m"
+  db:
+    image: postgres:9
+    volumes:
+      - ./docker/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+      - pg_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: tenejo
+
+  redis:
+    image: redis:4
+    volumes:
+      - redis_data:/data
+    ports:
+      - "6379:6379"
+  solr:
+    image: solr:6.5
+    volumes:
+      - ./solr/config:/opt/solr/server/solr/configsets/tenejo
+    ports:
+      - "8983:8983"
+    entrypoint:
+      - solr-precreate
+      - tenejo
+      - /opt/solr/server/solr/configsets/tenejo
+  solr_test:
+    image: solr:6.5
+    volumes:
+      - ./solr/config:/opt/solr/server/solr/configsets/tenejo
+    ports:
+      - "8985:8983"
+    entrypoint:
+      - solr-precreate
+      - tenejo
+      - /opt/solr/server/solr/configsets/tenejo
+volumes:
+  data:
+  bundle_dir:
+  derivatives:
+  fcrepo_data:
+  log:
+  pg_data:
+  redis_data:
+  solr_data:
+  tmp:
+  tenejo_tmp:
+  uploads:

--- a/docker/docker-entrypoint-initdb.d/initdb.sh
+++ b/docker/docker-entrypoint-initdb.d/initdb.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+	CREATE USER tenjo;
+	CREATE DATABASE tenejo_dev;
+  CREATE DATABASE tenejo_test;
+EOSQL

--- a/docker/start-app.sh
+++ b/docker/start-app.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+bundle check || bundle install
+find . -name *.pid -delete
+bundle exec rails s -b 0.0.0.0

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,6 +11,7 @@ require 'rspec/rails'
 require 'rspec/retry'
 require 'active_fedora/cleaner'
 require 'ffaker'
+require 'selenium-webdriver'
 
 # Add additional requires below this line. Rails is not loaded until this point!
 
@@ -27,10 +28,12 @@ require 'ffaker'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
+
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f } # rubocop:disable Rails/FilePath
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
+
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
@@ -39,15 +42,6 @@ RSpec.configure do |config|
   config.before(:suite) do
     ActiveJob::Base.queue_adapter = :test
     ActiveFedora::Cleaner.clean!
-  end
-
-  config.before(:each, type: :system) do
-    driven_by :selenium_chrome_headless, screen_size: [1920, 2080]
-    # Uncomment if you want to watch the browser
-    # driven_by :rack_test
-  end
-  config.after(:each, type: :system) do
-    driven_by :rack_test
   end
 
   config.before(clean: true) do

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Setup chrome headless driver
+Capybara.server = :puma, { Silent: true }
+
+Capybara.register_driver :chrome_headless do |app|
+  options = ::Selenium::WebDriver::Chrome::Options.new
+
+  options.add_argument('--headless')
+  options.add_argument('--no-sandbox')
+  options.add_argument('--disable-dev-shm-usage')
+  options.add_argument('--window-size=1400,1400')
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+Capybara.javascript_driver = :chrome_headless
+
+# Setup rspec
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
+
+  config.before(:each, type: :system, js: true) do
+    driven_by :chrome_headless
+  end
+end

--- a/spec/system/create_work_spec.rb
+++ b/spec/system/create_work_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.describe 'Create a Work', type: :system, clean: true, js: false do
+RSpec.describe 'Create a Work', type: :system, clean: true, js: true do
   context 'a logged in user' do
     let(:user_attributes) do
       { email: 'test@example.com' }


### PR DESCRIPTION
To start:

`docker-compse run web rails db:setup`
`docker-compose up`

Tenejo will be running on port 3000.

To run the specs:

`docker-compose run web rspec`

To use `byebug`:

After hitting the byebug in your code, run `docker ps` to get the id
for the `web` container. Copy that id and then run:

`docker attach 943094304`

Hit enter and you'll be in the byebug.

You'll find the bundled gems in the `bundle` folder. This
folder is gitignored to avoid commiting it.