### PR TITLE
Provide a mechanism to configure logging level by environment

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -34,3 +34,8 @@ SMTP_ADDRESS=smtp.example.com
 SMTP_PORT=587
 SMTP_USERNAME=someone
 SMTP_PASSWORD=something
+
+# Optionally set the log level for the target envionment
+# Valid options: debug, info, warn, error, fatal, & unknown
+# Note: do not include a colon here, the initializer will convert this string to a symbol
+# LOG_LEVEL=debug #

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,8 +49,9 @@ Rails.application.configure do
   # config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
+  # when problems arise.  This is extremely chatty, so we provide a mechanism to
+  # selectively reduce log output on production instances.
+  config.log_level = ENV['LOG_LEVEL'] || 'debug'
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
Note, this change takes advantage of the fact the the logger will
accept either a symbol or a string to set the level, so the
following two lines are equivalent:
```
config.log_level = :debug
config.log_level = 'debug'
```