### PR TITLE
Upgrade ruby to 2.6.3

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -1,5 +1,5 @@
 # Place any default configuration for solr_wrapper here
-version: 6.6.5
+version: 7.7.1
 # port: 8983
 instance_dir: tmp/solr-development
 collection:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,14 @@ dist: trusty
 jdk:
 - oraclejdk8
 rvm:
-- 2.5
+- 2.6.3
 addons:
   chrome: stable
 before_install:
   - sudo apt-get update
   - sudo apt-get install chromium-chromedriver
+  - gem update --system
+  - gem install bundler
 before_script:
   - export PATH=$PATH:/usr/lib/chromium-browser/
   - export DISPLAY=:99.0

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-ruby '>= 2.4.0', '<= 2.5.99'
+ruby '2.6.3'
 
 gem "actionview", ">= 5.1.6.2"
 gem 'clamby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -895,7 +895,7 @@ DEPENDENCIES
   zizia (~> 2.1.0.alpha.07)
 
 RUBY VERSION
-   ruby 2.5.5p157
+   ruby 2.6.3p62
 
 BUNDLED WITH
    2.0.2

--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -1,5 +1,5 @@
 #config/solr_wrapper_test.yml
-version: 6.6.5
+version: 7.7.1
 port: 8985
 instance_dir: tmp/solr-test
 download_dir: tmp/solr_downloads


### PR DESCRIPTION
This will match our latest standard build, and the expectations of the
Ubuntu 18.04 systems tenejo will run on.

Connected to https://github.com/curationexperts/in-house/issues/315