### PR TITLE
Update Zizia

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'sidekiq', '~> 5.1.3'
 gem 'turbolinks', '~> 5'
 gem 'uglifier', '>= 1.3.0' # Use Uglifier as compressor for JavaScript assets
 gem 'whenever', require: false
-gem 'zizia', '~> 4.5.3.alpha.01'
+gem 'zizia', '~> 4.5.4.alpha.01'
 
 group :development do
   # Use Capistrano for deployment automation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -835,7 +835,7 @@ GEM
     xml-simple (1.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zizia (4.5.3.alpha.01)
+    zizia (4.5.4.alpha.01)
       active-fedora
       carrierwave
       kaminari
@@ -891,7 +891,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
   whenever
-  zizia (~> 4.5.3.alpha.01)
+  zizia (~> 4.5.4.alpha.01)
 
 RUBY VERSION
    ruby 2.6.3p62

--- a/spec/importers/modular_importer_spec.rb
+++ b/spec/importers/modular_importer_spec.rb
@@ -19,7 +19,10 @@ RSpec.describe ModularImporter, :clean do
 
   it "imports a csv" do
     expect { ModularImporter.new(csv_import).import }.to change { Work.count }.by 2
-    expect(Work.first.title.first).to match(/nterior view/)
-    expect(Work.last.title.first).to match(/nterior view/)
+
+    # We can't guarantee that background jobs create this
+    # arrangement currently.
+    expect(Work.first.title.first).to match(/terior view/)
+    expect(Work.last.title.first).to match(/terior view/)
   end
 end


### PR DESCRIPTION
This removes the 'in Bytes' from the table headers.

These columns are human readable sizes now and not
bytes.

This also changes a spec that tested a specific
order for the rows. When you aren't running the jobs
inline you can't guarantee the order currently.