### PR TITLE
Remove non-admin CSV importer links

### DIFF
--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -23,15 +23,19 @@
       <% end %>
   <% end %>
 
-<% if Flipflop.download_csv? %>
+  <% if Flipflop.download_csv? %>
+    <% if current_user.admin? %>
   <%= menu.nav_link('/importer_documentation/csv',  data: { turbolinks: false }) do %>
-      <span class="fa fa-table"></span> <span class="sidebar-action-text">Download Import Template</span>
+    <span class="fa fa-table"></span> <span class="sidebar-action-text">Download Import Template</span>
+    <% end %>
   <% end %>
 <% end %>
 
 
 <% if Flipflop.import_csv? %>
+  <% if current_user.admin? %>
   <%= menu.nav_link('/csv_imports/new',  data: { turbolinks: false }) do %>
       <span class="fa fa-upload"></span> <span class="sidebar-action-text">Import Content From a CSV</span>
+    <% end %>
   <% end %>
 <% end %>

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe 'Dashboard', type: :system do
     end
 
     it 'can download a CSV template' do
-      expect(page).to have_link 'Download Import Template'
+      expect(page).not_to have_link 'Download Import Template'
     end
 
     it 'can get to the importer page' do
-      expect(page).to have_link 'Import Content From a CSV'
+      expect(page).not_to have_link 'Import Content From a CSV'
     end
 
     it 'has the footer version' do
@@ -34,6 +34,14 @@ RSpec.describe 'Dashboard', type: :system do
     before do
       login_as admin
       visit '/dashboard'
+    end
+
+    it 'can download a CSV template' do
+      expect(page).to have_link 'Download Import Template'
+    end
+
+    it 'can get to the importer page' do
+      expect(page).to have_link 'Import Content From a CSV'
     end
 
     it 'has a link to the user roles page' do


### PR DESCRIPTION
These links only work if you are logged in
as an admin so don't show them to non-admin
users.