### PR TITLE
Remove Import Content from sidebar

### DIFF
--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -22,13 +22,6 @@
           <span class="fa fa-line-chart"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.sidekiq') %></span>
       <% end %>
   <% end %>
-
-  <% if Flipflop.download_csv? %>
-    <% if current_user.admin? %>
-  <%= menu.nav_link('/importer_documentation/csv',  data: { turbolinks: false }) do %>
-    <span class="fa fa-table"></span> <span class="sidebar-action-text">Download Import Template</span>
-    <% end %>
-  <% end %>
 <% end %>
 
 

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Dashboard', type: :system do
       visit '/dashboard'
     end
 
-    it 'can download a CSV template' do
+    it 'does not have a CSV template' do
       expect(page).not_to have_link 'Download Import Template'
     end
 
@@ -36,8 +36,8 @@ RSpec.describe 'Dashboard', type: :system do
       visit '/dashboard'
     end
 
-    it 'can download a CSV template' do
-      expect(page).to have_link 'Download Import Template'
+    it 'does not have a link to a CSV template' do
+      expect(page).not_to have_link 'Download Import Template'
     end
 
     it 'can get to the importer page' do


### PR DESCRIPTION
This removes the link to download a
csv template from the sidebar.