### PR TITLE
Add simple_form translations to hyrax.en locale

### DIFF
--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1,5 +1,25 @@
 ---
 en:
+  simple_form:
+   labels:
+     defaults:
+       abstract: Abstract or Summary
+       based_near: Location
+       bibliographic_citation: Bibliographic Citation
+       contributor: Contributor
+       creator: Creator
+       date_created: Date Created
+       identifier: Identifier
+       keyword: Keyword
+       language: Language
+       license: License
+       publisher: Publisher
+       related_url: Related URL
+       resource_type: Resource Type
+       rights_statement: Rights Statement
+       source: Source
+       subject: Subject
+       title: Title
   blacklight:
     search:
       fields:

--- a/spec/system/create_work_spec.rb
+++ b/spec/system/create_work_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'Create a Work', type: :system, clean: true, js: true do
       fill_in('Title', with: 'My Test Work')
       fill_in('Creator', with: 'Doe, Jane')
       fill_in('Keyword', with: 'testing')
-      select('In Copyright', from: 'Rights statement')
+      select('In Copyright', from: 'Rights Statement')
 
       # With selenium and the chrome driver, focus remains on the
       # select box. Click outside the box so the next line can't find


### PR DESCRIPTION
This explicitly adds translations for the basic
metadata attributes on the form. This is so
that they show up in the guide.