### PR TITLE
Change default production log level to error

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,7 +51,7 @@ Rails.application.configure do
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.  This is extremely chatty, so we provide a mechanism to
   # selectively reduce log output on production instances.
-  config.log_level = ENV['LOG_LEVEL'] || 'debug'
+  config.log_level = ENV['LOG_LEVEL'] || 'error'
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
We can override this on a given server by setting the LOG_LEVEL
environment variable in .env.production, but to prevent an overwhelming
flood of logs, default to error, not debug.

Connected to https://github.com/curationexperts/in-house/issues/398