### PR TITLE
Password protect non-production instances

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,7 @@ class ApplicationController < ActionController::Base
   # Adds Hyrax behaviors into the application controller
   include Hyrax::Controller
   include Hyrax::ThemedLayoutController
+  include HttpAuthConcern
 
   # Check to see if we're in read_only mode
   before_action :check_read_only, except: [:show, :index]

--- a/app/controllers/concerns/http_auth_concern.rb
+++ b/app/controllers/concerns/http_auth_concern.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module HttpAuthConcern
+  extend ActiveSupport::Concern
+  included do
+    before_action :http_authenticate
+  end
+  def http_authenticate
+    return true unless ENV['HTTP_PASSWORD_PROTECT'] == 'true'
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV['HTTP_USERNAME'] && password == ENV['HTTP_PASSWORD']
+    end
+  end
+end

--- a/spec/system/password_protect_spec.rb
+++ b/spec/system/password_protect_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'Password protect non production instances', type: :system do
+  let(:login) { 'admin' }
+  let(:password) { 'whatever' }
+
+  before do
+    ENV['HTTP_USERNAME'] = login
+    ENV['HTTP_PASSWORD'] = password
+  end
+
+  context 'visiting an instance without HTTP_PASSWORD_PROTECT set' do
+    it 'does not prompt the user for a password' do
+      visit('/')
+      expect(page).to have_content('Tenejo')
+    end
+  end
+
+  context 'visiting an instance with HTTP_PASSWORD_PROTECT set' do
+    before do
+      ENV['HTTP_PASSWORD_PROTECT'] = 'true'
+    end
+    after do
+      ENV['HTTP_PASSWORD_PROTECT'] = 'false'
+    end
+    it 'prompts the user for a password' do
+      visit('/')
+      expect(page.find(:xpath, '//body').text).to eq "HTTP Basic: Access denied."
+    end
+  end
+end


### PR DESCRIPTION
To password protect an instance, set these environment variables:

HTTP_PASSWORD_PROTECT=true
HTTP_USERNAME=picksomething
HTTP_PASSWORD=yourpasswordhere

Connected to https://github.com/curationexperts/laevigata/issues/1976