### PR TITLE
Restart sidekiq with systemctl

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -6,48 +6,10 @@ set :application, "tenejo"
 set :repo_url, "https://github.com/curationexperts/tenejo.git"
 set :ssh_options, keys: ["tenejo-cd"] if File.exist?("tenejo-cd")
 
-# Default branch is :master
-# ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
-
-# Default deploy_to directory is /var/www/my_app_name
-# set :deploy_to, "/var/www/my_app_name"
-
-# Default value for :format is :airbrussh.
-# set :format, :airbrussh
-
-# You can configure the Airbrussh format using :format_options.
-# These are the defaults.
-# set :format_options, command_output: true, log_file: "log/capistrano.log", color: :auto, truncate: :auto
-
-# Default value for :pty is false
-# set :pty, true
-
-# Default value for :linked_files is []
-# append :linked_files, "config/database.yml"
-
-# Default value for linked_dirs is []
-# append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/system"
-
-# Default value for default_env is {}
-# set :default_env, { path: "/opt/ruby/bin:$PATH" }
-
-# Default value for local_user is ENV['USER']
-# set :local_user, -> { `git config user.name`.chomp }
-
-# Default value for keep_releases is 5
-# set :keep_releases, 5
-
-# Uncomment the following to require manually verifying the host key before first deploy.
-# set :ssh_options, verify_host_key: :secure
-
 set :deploy_to, '/opt/tenejo'
 set :rails_env, 'production'
 
-set :init_system, :systemd
-set :service_unit_name, 'sidekiq.service'
-set :sidekiq_user, 'deploy'
-
-set :log_level, :debug
+set :log_level, :warn
 set :bundle_flags, '--deployment'
 set :bundle_env_variables, nokogiri_use_system_libraries: 1
 
@@ -66,6 +28,30 @@ append :linked_dirs, "tmp/sockets"
 
 append :linked_files, ".env.production"
 append :linked_files, "config/secrets.yml"
+
+# We have to re-define capistrano-sidekiq's tasks to work with
+# systemctl in production. Note that you must clear the previously-defined
+# tasks before re-defining them.
+Rake::Task["sidekiq:stop"].clear_actions
+Rake::Task["sidekiq:start"].clear_actions
+Rake::Task["sidekiq:restart"].clear_actions
+namespace :sidekiq do
+  task :stop do
+    on roles(:app) do
+      execute :sudo, :systemctl, :stop, :sidekiq
+    end
+  end
+  task :start do
+    on roles(:app) do
+      execute :sudo, :systemctl, :start, :sidekiq
+    end
+  end
+  task :restart do
+    on roles(:app) do
+      execute :sudo, :systemctl, :restart, :sidekiq
+    end
+  end
+end
 
 # Capistrano passenger restart isn't working consistently,
 # so restart apache2 after a successful deploy, to ensure


### PR DESCRIPTION
* Continue using latest capistrano-sidekiq gem
* Go back to using root-owned systemctl process to manage sidekiq

After deploying with this branch, sidekiq restarts as expected:
![tenejo_dev_sidekiq](https://user-images.githubusercontent.com/65608/72542224-c95c5780-3851-11ea-8b95-6b1520f01116.png)
