### PR TITLE
Structure pre-docker readme to reflect proposed standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,19 @@
 Tenejo: a General Purpose Digital Repository
 ============================================
 
-[![CircleCI](https://circleci.com/gh/curationexperts/tenejo.svg?style=svg)](https://circleci.com/gh/curationexperts/tenejo) [![Apache 2.0 License](http://img.shields.io/badge/APACHE2-license-blue.svg)](./LICENSE) [![Maintainability](https://api.codeclimate.com/v1/badges/11b857b0d512575d91c5/maintainability)](https://codeclimate.com/github/curationexperts/tenejo/maintainability)
-
 Tenejo gives you the most commonly used Samvera features and functions in an easy to use hosted solution.
 
-Hosting
--------
-
-Contact [tenejo@curationexperts.com](mailto:tenejo@curationexperts.com) for information about Tenejo as a managed service for your institution.
+[![CircleCI](https://circleci.com/gh/curationexperts/tenejo.svg?style=svg)](https://circleci.com/gh/curationexperts/tenejo) [![Apache 2.0 License](http://img.shields.io/badge/APACHE2-license-blue.svg)](./LICENSE) [![Maintainability](https://api.codeclimate.com/v1/badges/11b857b0d512575d91c5/maintainability)](https://codeclimate.com/github/curationexperts/tenejo/maintainability)
 
 Development
 -----------
 
-1. `git clone https://github.com/curationexperts/tenejo.git`
-1. `cd ./tenejo` then check out a working branch `git checkout -b [meaningful_name]`
+### Prerequisites
 1. Ensure you have the prerequisites from https://github.com/samvera/hyrax, although you do not need a separately running Solr or Fedora instance in order to begin in development, since these are packaged with this application, in the form of solr_wrapper and fcrepo_wrapper.
+
+### Installing
+1. `git clone https://github.com/curationexperts/tenejo.git`
+1. `cd ./tenejo` then check out a working branch `git checkout -b my_working_branch`
 1. Copy `.env.sample` to `.env.development` if you want to override any default settings in your local development environment. Choose a random password for your local tenejo database user and add it to this file.
 1. Setup your database.
    We use PostgreSQL. To support the test and development environments, you'll
@@ -53,6 +51,7 @@ Development
 1. Run `bundle install`
 1. Run `bundle exec rake db:migrate` to setup the development database and schema.
 1. Start the servers, one per terminal window/tab - `fcrepo_wrapper`, `solr_wrapper`, `rails server`, and `sidekiq`
+### User and workflow setup
 1. (optional) Create standard accounts: `rake tenejo:standard_users_setup`.
 1. Create default collection types: `bundle exec rails hyrax:default_collection_types:create`
 1. `bundle exec rails hyrax:default_admin_set:create`
@@ -61,9 +60,3 @@ Development
 Production
 ----------
 1. Set `IIIF_SERVER_URL=http://SERVERNAME/cantaloupe/iiif/2/` to use an external cantaloupe IIIF server
-
-
-License
--------
-
-Tenejo is available under the [Apache License Version 2.0](./LICENSE).


### PR DESCRIPTION
Leaving proposed headings for which we have no pre-docker tenejo content out for now; avoiding merging README updates ahead of the functionality they document.

Co-Authored-By: Norm Orstad <norm0@users.noreply.github.com>