### PR TITLE
Use one solr instance with two cores in docker-compose

### DIFF
--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -3,7 +3,7 @@ development:
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_DEVELOPMENT_PORT', 8983)}/solr/hydra-development" %>
 test: &test
   adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_TEST_PORT', 8985)}/solr/hydra-test" %>
+  url: <%= ENV['SOLR_TEST_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_TEST_PORT', 8985)}/solr/hydra-test" %>
 production:
   adapter: solr
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/tenejo" %>

--- a/config/solr.yml
+++ b/config/solr.yml
@@ -2,6 +2,6 @@
 development:
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV['SOLR_TEST_PORT'] || 8983}/solr/hydra-development" %>
 test:
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV['SOLR_TEST_PORT'] || 8985}/solr/hydra-test" %>
+  url: <%= ENV['SOLR_TEST_URL'] || "http://127.0.0.1:#{ENV['SOLR_TEST_PORT'] || 8985}/solr/hydra-test" %>
 production:
   url: http://127.0.0.1:8983/solr/tenejo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       - redis
       - solr
       - fedora_test
-      - solr_test
     env_file:
       - ./.env.${RAILS_ENV:-development}
     environment:
@@ -26,8 +25,8 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_URL: redis://redis:6379/0
-      SOLR_URL: http://solr:8983/solr/tenejo
-      SOLR_TEST_URL: http://solr_test:8983/solr/tenejo
+      SOLR_URL: http://solr:8983/solr/hydra-development
+      SOLR_TEST_URL: http://solr:8983/solr/hydra-test
     ports:
       - "3000:3000"
     volumes:
@@ -62,8 +61,8 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_URL: redis://redis:6379/0
-      SOLR_URL: http://solr:8983/solr/tenejo
-      SOLR_TEST_URL: http://solr_test:8983/solr/tenejo
+      SOLR_URL: http://solr:8983/solr/hydra-development
+      SOLR_TEST_URL: http://solr:8983/solr/hydra-test
     volumes:
       - .:/tenejo
       - data:/opt/data
@@ -111,20 +110,7 @@ services:
       - ./solr/config:/opt/solr/server/solr/configsets/tenejo
     ports:
       - "8983:8983"
-    entrypoint:
-      - solr-precreate
-      - tenejo
-      - /opt/solr/server/solr/configsets/tenejo
-  solr_test:
-    image: solr:6.5
-    volumes:
-      - ./solr/config:/opt/solr/server/solr/configsets/tenejo
-    ports:
-      - "8985:8983"
-    entrypoint:
-      - solr-precreate
-      - tenejo
-      - /opt/solr/server/solr/configsets/tenejo
+    command: bash -c 'precreate-core hydra-development /opt/solr/server/solr/configsets/tenejo; precreate-core hydra-test /opt/solr/server/solr/configsets/tenejo; exec solr -f'
 volumes:
   data:
   bundle_dir:


### PR DESCRIPTION
- More sensible test environment configuration for blacklight and solr for SOLR_URL and SOLR_TEST_URL
- Align with default core names for now
- Have both solr's on port 8983

Connected to: https://github.com/curationexperts/in-house/issues/698

Co-authored-by: Rachel Kadel <rachel.kadel@curationexperts.com>