### PR TITLE
Add setup commands to docker startup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,9 @@ jobs:
                 type: string
                 default: 2.0.1
         environment:
+          DATABASE_URL: postgresql://postgres@127.0.0.1/circle_test
           DATABASE_NAME: circle_test
           DATABASE_USERNAME: postgres
-          POSTGRES_DB: tenejo_test
           POSTGRES_HOST: 127.0.0.1
           POSTGRES_USER: postgres
           WORKING_PATH: /tmp

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,7 +6,7 @@ default: &default
   password: <%= ENV['DATABASE_PASSWORD'] %>
   pool:     <%= ENV['DATABASE_POOL_SIZE'] || 5 %>
   timeout:  5000
-  database: <%= ENV['DATABASE_NAME'] %>
+
 
 development:
   <<: *default
@@ -17,6 +17,8 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
+  database: <%= ENV["CI"] == true ? "circle_test" : "tenejo_test" %>
 
 production:
   <<: *default
+  database: <%= ENV['DATABASE_NAME'] %>

--- a/docker/start-app.sh
+++ b/docker/start-app.sh
@@ -3,4 +3,7 @@
 bundle check || bundle install
 find . -name *.pid -delete
 bundle exec rake db:create && bundle exec rake db:migrate
+bundle exec rake tenejo:standard_users_setup
+bundle exec rails hyrax:default_collection_types:create
+bundle exec rails hyrax:default_admin_set:create
 bundle exec rails s -b 0.0.0.0

--- a/lib/tasks/tenejo.rake
+++ b/lib/tasks/tenejo.rake
@@ -2,8 +2,12 @@
 namespace :tenejo do
   desc "Setup standard login accounts"
   task standard_users_setup: :environment do
-    create_first_user
-    create_first_admin_user
+    if ENV["RAILS_ENV"] != "production"
+      create_first_user
+      create_first_admin_user
+    else
+      puts "Rails running in production mode, not creating first user or first admin"
+    end
   end
 
   desc "Cleanup all uploaded files and delete all user accounts"


### PR DESCRIPTION
- Pull in change to database config so tests still pass locally & in ci (separate DBs)
- Add guard clause around standard tenejo user creation so that it won't run accidentally in production mode

Connected to https://github.com/curationexperts/in-house/issues/707