### PR TITLE
Remove navigation steps from create work spec

### DIFF
--- a/spec/system/create_work_spec.rb
+++ b/spec/system/create_work_spec.rb
@@ -34,15 +34,7 @@ RSpec.describe 'Create a Work', type: :system, clean: true, js: true do
     end
 
     scenario do
-      visit '/dashboard'
-      click_link "Works"
-      expect(page).to have_link "Add new work"
-      click_link "Add new work"
-
-      # If you generate more than one work uncomment these lines
-      # choose "payload_concern", option: "Work"
-      # click_button "Create work"
-
+      visit '/concern/works/new'
       expect(page).to have_content "Add New Work"
       click_link "Files" # switch tab
       expect(page).to have_content "Add files"


### PR DESCRIPTION
The navigation portions of the test rely on capybara matcher that may
timeout when loading the intermediate dashboard pages that occurr
in the user navigation flow before arriving at the new work form.

This assumes that the navigation to the page is not a primary concern
of the test and just loads the form view immediately.