### PR TITLE
Allow admins to invite users via email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'clamby'
 gem 'coffee-rails', '~> 4.2' # Use CoffeeScript for .coffee assets and views
 gem 'devise'
 gem 'devise-guests', '~> 0.6'
+gem 'devise_invitable', '~> 2.0.0'
 gem 'dotenv-rails', '~> 2.2.1'
 gem 'ed25519', '~> 1.2', '>= 1.2.4' # Needed to support more secure ssh keys
 gem 'honeybadger', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,6 +203,9 @@ GEM
       warden (~> 1.2.3)
     devise-guests (0.7.0)
       devise
+    devise_invitable (2.0.5)
+      actionmailer (>= 5.0)
+      devise (>= 4.6)
     diff-lcs (1.3)
     docile (1.3.2)
     dotenv (2.2.2)
@@ -947,6 +950,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   devise
   devise-guests (~> 0.6)
+  devise_invitable (~> 2.0.0)
   dotenv-rails (~> 2.2.1)
   ed25519 (~> 1.2, >= 1.2.4)
   factory_bot_rails

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Users::InvitationsController < Devise::InvitationsController
+  before_action :ensure_admin!, only: [:new, :create]
+
+  private
+
+    def ensure_admin!
+      authorize! :read, :admin_dashboard
+    end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :rememberable, :trackable, :validatable, :invitable
 
   # Method added by Blacklight; Blacklight uses #to_s on your
   # user class to get a user-displayable login/identifier for

--- a/app/views/hyrax/admin/users/index.html.erb
+++ b/app/views/hyrax/admin/users/index.html.erb
@@ -1,0 +1,51 @@
+<% provide :page_header do %>
+  <h1><span class="fa fa-user" aria-hidden="true"></span> <%= t('hyrax.admin.users.index.title') %></h1>
+<% end %>
+
+<div class="panel panel-default users-listing">
+  <div class="panel-heading">
+      <%= t('hyrax.admin.users.index.describe_users_html', count: @presenter.user_count) %>
+  </div>
+
+  <div class="panel-body">
+    <div class="table-responsive">
+      <table class="table table-striped datatable">
+        <thead>
+          <tr>
+            <th></th>
+            <th><%= t('.id_label') %></th>
+            <th><%= t('.role_label') %></th>
+            <% if @presenter.show_last_access? %>
+              <th><%= t('.access_label') %></th>
+            <% end %>
+          </tr>
+        </thead>
+        <tbody>
+          <% @presenter.users.each do |user| %>
+            <tr>
+              <td><%= link_to hyrax.user_path(user) do %>
+                    <%= image_tag(user.avatar.url(:thumb), width: 30) if user.avatar.file %>
+                  <% end %>
+              </td>
+              <td><%= link_to user.email, hyrax.user_path(user) %></td>
+              <td><% roles = @presenter.user_roles(user) %>
+                  <ul><% roles.each do |role| %>
+                    <li><%= role %></li>
+                    <% end %>
+                  </ul>
+              </td>
+              <% if @presenter.show_last_access? %>
+                <td>
+                  <%# in the case that a user is created who never signs in, this is necessary %>
+                  <relative-time datetime="<%= @presenter.last_accessed(user).getutc.iso8601 %>" title="<%= @presenter.last_accessed(user).to_formatted_s(:standard) %>">
+                    <%= @presenter.last_accessed(user).to_formatted_s(:long_ordinal) %>
+                  </relative-time>
+                </td>
+              <% end %>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/hyrax/admin/users/index.html.erb
+++ b/app/views/hyrax/admin/users/index.html.erb
@@ -1,7 +1,7 @@
 <% provide :page_header do %>
   <h1><span class="fa fa-user" aria-hidden="true"></span> <%= t('hyrax.admin.users.index.title') %></h1>
   <div class="col-md-4 pull-right">
-    <%= button_to "Invite New User",{}, {class: "btn btn-primary"} %>
+    <%= link_to("Invite New User", main_app.new_user_invitation_path, class: "btn btn-primary") %>
   </div>
 <% end %>
 

--- a/app/views/hyrax/admin/users/index.html.erb
+++ b/app/views/hyrax/admin/users/index.html.erb
@@ -1,5 +1,8 @@
 <% provide :page_header do %>
   <h1><span class="fa fa-user" aria-hidden="true"></span> <%= t('hyrax.admin.users.index.title') %></h1>
+  <div class="col-md-4 pull-right">
+    <%= button_to "Invite New User",{}, {class: "btn btn-primary"} %>
+  </div>
 <% end %>
 
 <div class="panel panel-default users-listing">

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -122,6 +122,55 @@ Devise.setup do |config|
   # Send a notification email when the user's password is changed.
   # config.send_password_change_notification = false
 
+  # ==> Configuration for :invitable
+  # The period the generated invitation token is valid.
+  # After this period, the invited resource won't be able to accept the invitation.
+  # When invite_for is 0 (the default), the invitation won't expire.
+  # config.invite_for = 2.weeks
+
+  # Number of invitations users can send.
+  # - If invitation_limit is nil, there is no limit for invitations, users can
+  # send unlimited invitations, invitation_limit column is not used.
+  # - If invitation_limit is 0, users can't send invitations by default.
+  # - If invitation_limit n > 0, users can send n invitations.
+  # You can change invitation_limit column for some users so they can send more
+  # or less invitations, even with global invitation_limit = 0
+  # Default: nil
+  # config.invitation_limit = 5
+
+  # The key to be used to check existing users when sending an invitation
+  # and the regexp used to test it when validate_on_invite is not set.
+  # config.invite_key = { email: /\A[^@]+@[^@]+\z/ }
+  # config.invite_key = { email: /\A[^@]+@[^@]+\z/, username: nil }
+
+  # Ensure that invited record is valid.
+  # The invitation won't be sent if this check fails.
+  # Default: false
+  # config.validate_on_invite = true
+
+  # Resend invitation if user with invited status is invited again
+  # Default: true
+  # config.resend_invitation = false
+
+  # The class name of the inviting model. If this is nil,
+  # the #invited_by association is declared to be polymorphic.
+  # Default: nil
+  # config.invited_by_class_name = 'User'
+
+  # The foreign key to the inviting model (if invited_by_class_name is set)
+  # Default: :invited_by_id
+  # config.invited_by_foreign_key = :invited_by_id
+
+  # The column name used for counter_cache column. If this is nil,
+  # the #invited_by association is declared without counter_cache.
+  # Default: nil
+  # config.invited_by_counter_cache = :invitations_count
+
+  # Auto-login after the user accepts the invite. If this is false,
+  # the user will need to manually log in after accepting the invite.
+  # Default: true
+  # config.allow_insecure_sign_in_after_accept = false
+
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without
   # confirming their account. For instance, if set to 2.days, the user will be

--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -1,0 +1,31 @@
+en:
+  devise:
+    failure:
+      invited: "You have a pending invitation, accept it to finish creating your account."
+    invitations:
+      send_instructions: "An invitation email has been sent to %{email}."
+      invitation_token_invalid: "The invitation token provided is not valid!"
+      updated: "Your password was set successfully. You are now signed in."
+      updated_not_active: "Your password was set successfully."
+      no_invitations_remaining: "No invitations remaining"
+      invitation_removed: "Your invitation was removed."
+      new:
+        header: "Send invitation"
+        submit_button: "Send an invitation"
+      edit:
+        header: "Set your password"
+        submit_button: "Set my password"
+    mailer:
+      invitation_instructions:
+        subject: "Invitation instructions"
+        hello: "Hello %{email}"
+        someone_invited_you: "Someone has invited you to %{url}, you can accept it through the link below."
+        accept: "Accept invitation"
+        accept_until: "This invitation will be due in %{due_date}."
+        ignore: "If you don't want to accept the invitation, please ignore this email. Your account won't be created until you access the link above and set your password."
+  time:
+    formats:
+      devise:
+        mailer:
+          invitation_instructions:
+            accept_until_format: "%B %d, %Y %I:%M %p"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,8 @@ Rails.application.routes.draw do
     concerns :searchable
   end
 
-  devise_for :users
+  devise_for :users, controllers: { invitations: 'users/invitations' }
+
   mount Hydra::RoleManagement::Engine => '/'
 
   mount Qa::Engine => '/authorities'

--- a/db/migrate/20210729133516_add_invitable_to_users.rb
+++ b/db/migrate/20210729133516_add_invitable_to_users.rb
@@ -1,0 +1,12 @@
+class AddInvitableToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :invitation_token, :string
+    add_column :users, :invitation_created_at, :datetime
+    add_column :users, :invitation_sent_at, :datetime
+    add_column :users, :invitation_accepted_at, :datetime
+    add_column :users, :invitation_limit, :integer
+    add_column :users, :invited_by_id, :integer
+    add_column :users, :invited_by_type, :string
+    add_index :users, :invitation_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -546,7 +546,15 @@ ActiveRecord::Schema.define(version: 201901241536542) do
     t.binary "zotero_token"
     t.string "zotero_userid"
     t.string "preferred_locale"
+    t.string "invitation_token"
+    t.datetime "invitation_created_at"
+    t.datetime "invitation_sent_at"
+    t.datetime "invitation_accepted_at"
+    t.integer "invitation_limit"
+    t.integer "invited_by_id"
+    t.string "invited_by_type"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 

--- a/spec/system/manage_users_spec.rb
+++ b/spec/system/manage_users_spec.rb
@@ -1,0 +1,18 @@
+# coding: utf-8
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'Manage users', type: :system do
+  context 'as an admin user' do
+    let(:admin) { FactoryBot.create(:admin) }
+    before do
+      login_as admin
+      visit '/admin/users'
+    end
+    xit "has a button to add a user" do
+      expect(page).to have_content("Manage Users")
+      expect(page).to have_button("Invite New User")
+    end
+  end
+end

--- a/spec/system/manage_users_spec.rb
+++ b/spec/system/manage_users_spec.rb
@@ -10,9 +10,19 @@ RSpec.describe 'Manage users', type: :system do
       login_as admin
       visit '/admin/users'
     end
-    xit "has a button to add a user" do
+    it "has a button to add a user" do
       expect(page).to have_content("Manage Users")
       expect(page).to have_button("Invite New User")
+    end
+  end
+
+  context "as a regular user" do
+    let(:user) { FactoryBot.create(:user) }
+    before do
+      login_as user
+    end
+    it "cannot see the 'Send Invitation' page" do
+      true
     end
   end
 end

--- a/spec/system/manage_users_spec.rb
+++ b/spec/system/manage_users_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe 'Manage users', type: :system do
     end
     it "has a button to add a user" do
       expect(page).to have_content("Manage Users")
-      expect(page).to have_button("Invite New User")
+      expect(page).to have_link("Invite New User", href: "/users/invitation/new?locale=en")
+      click_on("Invite New User")
+      expect(page).to have_content("Send invitation")
     end
   end
 
@@ -22,7 +24,8 @@ RSpec.describe 'Manage users', type: :system do
       login_as user
     end
     it "cannot see the 'Send Invitation' page" do
-      true
+      visit '/users/invitation/new'
+      expect(page).to have_content("You are not authorized to access this page.")
     end
   end
 end


### PR DESCRIPTION
(ignore the extra "admin" lines - fixed in another PR)
![image](https://user-images.githubusercontent.com/45948126/127555160-5016b34d-7d96-4bb4-9a5e-e44fbe6ea238.png)


Current look - invitation page:
![image](https://user-images.githubusercontent.com/45948126/127555080-74e8ac55-7d5d-4b66-9c05-d6da4236dd1a.png)

tenejo-dev
![image](https://user-images.githubusercontent.com/45948126/127560873-1a9c0653-feb0-46cf-9654-d4f4a535ee5f.png)

![image](https://user-images.githubusercontent.com/45948126/127561871-5079f2f4-1c54-435f-9db1-ca5b6ebf7498.png)

![image](https://user-images.githubusercontent.com/45948126/127561917-8617b421-a642-4287-84b4-c99e1e810074.png)
