### PR TITLE
Use local ./tmp directory for file upload and download in examples

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -24,8 +24,8 @@ ADMIN_PASSWORD=123456
 UPLOAD_PATH=tmp/uploads
 CACHE_PATH=tmp/uploads/cache
 WORKING_PATH=tmp/uploads
-
-IMPORT_PATH=/path/to/your/images
+DERIVATIVES_PATH=tmp/derivatives
+IMPORT_PATH=tmp/import			
 
 GA_TRACKING_CODE=UA-not-a-real-code-1
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Development
 1. (optional) Create standard accounts: `rake tenejo:standard_users_setup`.
 1. Create default collection types: `bundle exec rails hyrax:default_collection_types:create`
 1. `bundle exec rails hyrax:default_admin_set:create`
-1. Make sure your computer has directories `/opt/uploads/` and `/opt/derivatives` that you own
 
 Production
 ----------


### PR DESCRIPTION
Changing the `.env.sample` defaults and using them to seed
`.env.development` keeps the development enviroment contained and
eliminates the need to create an `/opt` directory on local dev systems.