### PR TITLE
Add warning on import page if antivirus software isn't running

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -sS https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add
 RUN apt-get update -qq && apt install -y --no-install-recommends postgresql-client build-essential libpq-dev imagemagick libreoffice ffmpeg unzip clamav clamav-freshclam clamav-daemon openjdk-8-jre-headless apt-transport-https build-essential git vim google-chrome-stable
 
 # Chromedriver
-RUN curl -sS https://chromedriver.storage.googleapis.com/89.0.4389.23/chromedriver_linux64.zip > chromedriver_linux64.zip
+RUN curl -sS https://chromedriver.storage.googleapis.com/92.0.4515.43/chromedriver_linux64.zip > chromedriver_linux64.zip
 RUN unzip chromedriver_linux64.zip -d /usr/local/bin
 RUN rm -f chromedriver_linux64.zip
 

--- a/app/controllers/zizia/csv_imports_controller.rb
+++ b/app/controllers/zizia/csv_imports_controller.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+module Zizia
+  class CsvImportsController < ::ApplicationController
+    load_and_authorize_resource
+    before_action :load_and_authorize_preview, only: [:preview]
+    before_action :clamd_running?, only: [:new]
+
+    with_themed_layout 'dashboard'
+
+    def index; end
+
+    def show; end
+
+    def new; end
+
+    # Validate the CSV file and display errors or
+    # warnings to the user.
+    def preview; end
+
+    def create
+      @csv_import.user = current_user
+      preserve_cache
+
+      if @csv_import.save
+        @csv_import.queue_start_job
+        redirect_to @csv_import
+      else
+        render :new
+      end
+    end
+
+    private
+
+      def clamd_running?
+        byebug
+        @clamd_running = list_clamd_service.present?
+      end
+
+      def list_clamd_service
+        `ps ax | grep [c]lamd`
+      end
+
+      def load_and_authorize_preview
+        @csv_import = CsvImport.new(create_params)
+        authorize! :create, @csv_import
+      end
+
+      def create_params
+        params.fetch(:csv_import, {}).permit(:manifest, :fedora_collection_id, :update_actor_stack)
+      end
+
+      # Since we are re-rendering the form (once for
+      # :new and again for :preview), we need to
+      # manually set the cache, otherwise the record
+      # will lose the manifest file between the preview
+      # and the record save.
+      def preserve_cache
+        return unless params['csv_import']
+        @csv_import.manifest_cache = params['csv_import']['manifest_cache']
+        @csv_import.fedora_collection_id = params['csv_import']['fedora_collection_id']
+        @csv_import.update_actor_stack = params['csv_import']['update_actor_stack']
+      end
+  end
+end

--- a/app/controllers/zizia/csv_imports_controller.rb
+++ b/app/controllers/zizia/csv_imports_controller.rb
@@ -32,7 +32,6 @@ module Zizia
     private
 
       def clamd_running?
-        byebug
         @clamd_running = list_clamd_service.present?
       end
 

--- a/app/controllers/zizia/csv_imports_controller.rb
+++ b/app/controllers/zizia/csv_imports_controller.rb
@@ -3,7 +3,7 @@ module Zizia
   class CsvImportsController < ::ApplicationController
     load_and_authorize_resource
     before_action :load_and_authorize_preview, only: [:preview]
-    before_action :clamd_running?, only: [:new]
+    before_action :antivirus_running?, only: [:new]
 
     with_themed_layout 'dashboard'
 
@@ -31,11 +31,12 @@ module Zizia
 
     private
 
-      def clamd_running?
-        @clamd_running = list_clamd_service.present?
+      def antivirus_running?
+        @antivirus_running = list_antivirus_service.present?
       end
 
-      def list_clamd_service
+      # TODO: Is there a way to make this more service-neutral? Put name of service in configuration?
+      def list_antivirus_service
         `ps ax | grep [c]lamd`
       end
 

--- a/app/views/zizia/csv_imports/new.html.erb
+++ b/app/views/zizia/csv_imports/new.html.erb
@@ -1,8 +1,8 @@
 <%= javascript_include_tag 'zizia/application' %>
 <div id="zizia_new" class="zizia">
   <h2><span class="glyphicon glyphicon-cloud-upload"></span> Batch Import </h2>
-  <% unless @clamd_running %>
-    <p>WARNING: antivirus is not configured correctly, please contact your system administrator</p>
+  <% unless @antivirus_running %>
+    <h3><span style="color:red">WARNING:</span> antivirus is not configured correctly, please contact your system administrator</h3>
   <% end %>
   <%= render 'form', csv_import: @csv_import %>
 </div>

--- a/app/views/zizia/csv_imports/new.html.erb
+++ b/app/views/zizia/csv_imports/new.html.erb
@@ -1,0 +1,8 @@
+<%= javascript_include_tag 'zizia/application' %>
+<div id="zizia_new" class="zizia">
+  <h2><span class="glyphicon glyphicon-cloud-upload"></span> Batch Import </h2>
+  <% unless @clamd_running %>
+    <p>WARNING: antivirus is not configured correctly, please contact your system administrator</p>
+  <% end %>
+  <%= render 'form', csv_import: @csv_import %>
+</div>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - log:/tenejo/log
       - tenejo_tmp:/tenejo/tmp
       - tmp:/tmp
+      - clam:/var/lib/clamav
     working_dir: /tenejo
     stdin_open: true
     tty: true
@@ -78,3 +79,4 @@ volumes:
   tmp:
   tenejo_tmp:
   uploads:
+  clam:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - solr
     environment:
       DATABASE_HOST: db
+      DATABASE_USERNAME: tenejo
       DATABASE_PASSWORD: postgres
       FEDORA_PORT: 8080
       FEDORA_TEST_URL: http://fedora:8080/rest
@@ -52,7 +53,6 @@ services:
     environment:
       POSTGRES_USER: tenejo
       POSTGRES_PASSWORD: postgres
-
   redis:
     image: redis:4
     volumes:

--- a/spec/system/import_system_warnings_spec.rb
+++ b/spec/system/import_system_warnings_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe 'Showing background services warnings on import page', :perform_j
   let(:clamd_warning) { 'WARNING: antivirus is not configured correctly, please contact your system administrator' }
   before do
     login_as admin_user
-    visit '/csv_imports/new'
   end
   context "with clamd stopped" do
-
     it "shows a warning on the page if clamd is down" do
-      allow_any_instance_of(Zizia::CsvImportsController).to receive(:list_clamd_service).and_return("testing")
-
+      allow_any_instance_of(Zizia::CsvImportsController).to receive(:list_clamd_service).and_return("")
+      visit '/csv_imports/new'
+      # imports_controller_mock = Zizia::CsvImportsController.new
+      # allow(imports_controller_mock).to receive(:list_clamd_service).and_return("testing")
       expect(page).to have_content 'Batch Import'
       expect(page).to have_content clamd_warning
 
@@ -24,9 +24,8 @@ RSpec.describe 'Showing background services warnings on import page', :perform_j
   context "with clamd running" do
     it "does not show a warning about clamd" do
       allow_any_instance_of(Zizia::CsvImportsController).to receive(:list_clamd_service).and_return("472 ?        Ssl    0:00 /usr/sbin/clamd -c /etc/clamav/clamd.conf --pid=/run/clamav/clamd.pid")
-
+      visit '/csv_imports/new'
       expect(page).not_to have_content clamd_warning
     end
   end
-
 end

--- a/spec/system/import_system_warnings_spec.rb
+++ b/spec/system/import_system_warnings_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'Showing background services warnings on import page', :perform_jobs, :clean, type: :system, js: true do
+  let(:admin_user) { FactoryBot.create(:admin) }
+  let(:clamd_warning) { 'WARNING: antivirus is not configured correctly, please contact your system administrator' }
+  before do
+    login_as admin_user
+    visit '/csv_imports/new'
+  end
+  context "with clamd stopped" do
+
+    it "shows a warning on the page if clamd is down" do
+      allow_any_instance_of(Zizia::CsvImportsController).to receive(:list_clamd_service).and_return("testing")
+
+      expect(page).to have_content 'Batch Import'
+      expect(page).to have_content clamd_warning
+
+      # ps ax | grep [c]lamd
+    end
+  end
+
+  context "with clamd running" do
+    it "does not show a warning about clamd" do
+      allow_any_instance_of(Zizia::CsvImportsController).to receive(:list_clamd_service).and_return("472 ?        Ssl    0:00 /usr/sbin/clamd -c /etc/clamav/clamd.conf --pid=/run/clamav/clamd.pid")
+
+      expect(page).not_to have_content clamd_warning
+    end
+  end
+
+end

--- a/spec/system/import_system_warnings_spec.rb
+++ b/spec/system/import_system_warnings_spec.rb
@@ -8,22 +8,18 @@ RSpec.describe 'Showing background services warnings on import page', :perform_j
   before do
     login_as admin_user
   end
-  context "with clamd stopped" do
-    it "shows a warning on the page if clamd is down" do
-      allow_any_instance_of(Zizia::CsvImportsController).to receive(:list_clamd_service).and_return("")
+  context "with antivirus stopped" do
+    it "shows a warning on the page" do
+      allow_any_instance_of(Zizia::CsvImportsController).to receive(:list_antivirus_service).and_return("")
       visit '/csv_imports/new'
-      # imports_controller_mock = Zizia::CsvImportsController.new
-      # allow(imports_controller_mock).to receive(:list_clamd_service).and_return("testing")
       expect(page).to have_content 'Batch Import'
       expect(page).to have_content clamd_warning
-
-      # ps ax | grep [c]lamd
     end
   end
 
-  context "with clamd running" do
+  context "with antivirus running" do
     it "does not show a warning about clamd" do
-      allow_any_instance_of(Zizia::CsvImportsController).to receive(:list_clamd_service).and_return("472 ?        Ssl    0:00 /usr/sbin/clamd -c /etc/clamav/clamd.conf --pid=/run/clamav/clamd.pid")
+      allow_any_instance_of(Zizia::CsvImportsController).to receive(:list_antivirus_service).and_return("472 ? Ssl 0:00 /usr/sbin/clamd -c /etc/clamav/clamd.conf --pid=/run/clamav/clamd.pid")
       visit '/csv_imports/new'
       expect(page).not_to have_content clamd_warning
     end


### PR DESCRIPTION
- Update to latest chromedriver in Docker to match Chrome
- Check antivirus in import controller
- Display warning if antivirus is not running

![image](https://user-images.githubusercontent.com/45948126/129382376-8471ac84-741c-479b-b171-cf7e364e4d2f.png)
