### PR TITLE
Add xray-rails to facilitate debugging views and partials

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ group :development do
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'web-console', '>= 3.3.0'
+  gem 'xray-rails'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -925,6 +925,8 @@ GEM
     xml-simple (1.1.8)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    xray-rails (0.3.2)
+      rails (>= 3.1.0)
     zizia (6.0.1)
       active-fedora
       carrierwave
@@ -985,6 +987,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
   whenever
+  xray-rails
   zizia (~> 6.0.1)
 
 RUBY VERSION


### PR DESCRIPTION
After starting the development server and visiting a page in your
browser, hit CMD-SHIFT-X (Mac) or CTRL-SHIFT-X (Windows) to display
the veiw's partials in your browser.

See more at https://github.com/brentd/xray-rails.