### PR TITLE
Refactor service checks to be more dry and consistent

### DIFF
--- a/app/views/zizia/csv_imports/_service_warning.html.erb
+++ b/app/views/zizia/csv_imports/_service_warning.html.erb
@@ -1,0 +1,1 @@
+<h3><span style="color:red">WARNING:</span> <%= service %> is not configured correctly, please contact your system administrator</h3>

--- a/app/views/zizia/csv_imports/_service_warning.html.erb
+++ b/app/views/zizia/csv_imports/_service_warning.html.erb
@@ -1,1 +1,1 @@
-<h3><span style="color:red">WARNING:</span> <%= service.to_s %> is not configured correctly, please contact your system administrator</h3>
+<h3><span style="color:red">WARNING:</span> <%= service %> is not configured correctly, please contact your system administrator</h3>

--- a/app/views/zizia/csv_imports/_service_warning.html.erb
+++ b/app/views/zizia/csv_imports/_service_warning.html.erb
@@ -1,0 +1,1 @@
+<h3><span style="color:red">WARNING:</span> <%= service.to_s %> is not configured correctly, please contact your system administrator</h3>

--- a/app/views/zizia/csv_imports/new.html.erb
+++ b/app/views/zizia/csv_imports/new.html.erb
@@ -2,13 +2,13 @@
 <div id="zizia_new" class="zizia">
   <h2><span class="glyphicon glyphicon-cloud-upload"></span> Batch Import </h2>
   <% unless @antivirus_running %>
-    <h3><span style="color:red">WARNING:</span> antivirus is not configured correctly, please contact your system administrator</h3>
+    <%= render 'service_warning', service: "antivirus" %>
   <% end %>
   <% unless @image_conversion_running %>
-    <h3><span style="color:red">WARNING:</span> image conversion is not configured correctly, please contact your system administrator</h3>
+    <%= render 'service_warning', service: "image conversion" %>
   <% end %>
   <% unless @audiovisual_conversion_running %>
-    <h3><span style="color:red">WARNING:</span> media processing is not configured correctly, please contact your system administrator</h3>
+    <%= render 'service_warning', service: "media processing" %>
   <% end %>
   <%= render 'form', csv_import: @csv_import %>
 </div>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -52,6 +52,7 @@ RSpec.configure do |config|
   config.before do |_example|
     class_double("Clamby").as_stubbed_const
     allow(Clamby).to receive(:virus?).and_return(false)
+    allow(Clamby).to receive(:safe?).and_return(true)
   end
 
   # We use an EICAR-STANDARD-ANTIVIRUS-TEST-FILE, but when stubbing virus checks

--- a/spec/system/virus_scan_spec.rb
+++ b/spec/system/virus_scan_spec.rb
@@ -3,49 +3,47 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 RSpec.describe 'Virus Scanning', :clean, :js, :virus_scan, type: :system do
-  xit 'handles virus uploads correctly' do
-    let(:admin) { FactoryBot.create(:admin) }
-    before { login_as admin }
-    after  { logout }
+  let(:admin) { FactoryBot.create(:admin) }
+  before { login_as admin }
+  after  { logout }
 
-    let(:safe_path)  { "#{fixture_path}/images/cat.jpg" }
-    let(:virus_path) { "#{fixture_path}/virus_check.txt" }
+  let(:safe_path)  { "#{fixture_path}/images/cat.jpg" }
+  let(:virus_path) { "#{fixture_path}/virus_check.txt" }
 
-    scenario 'uploading a file with a virus', :perform_jobs do
-      ActiveJob::Base.queue_adapter.filter = [AttachFilesToWorkJob, IngestJob]
+  scenario 'uploading a file with a virus', :perform_jobs do
+    ActiveJob::Base.queue_adapter.filter = [AttachFilesToWorkJob, IngestJob]
 
-      visit('/concern/works/new')
-      click_link('Files')
+    visit('/concern/works/new')
+    click_link('Files')
 
-      within('#addfiles') do
-        attach_file('files[]', safe_path, visible: false, wait: 5)
-        attach_file('files[]', virus_path, visible: false, wait: 5)
-      end
-
-      click_link('Descriptions')
-      fill_in 'Title', with: 'A Work with a Virus'
-      fill_in 'Creator', with: 'Dmitri Ivanovsky'
-      fill_in 'Keyword', with: 'pathogens'
-      select('No Known Copyright', from: 'Rights')
-
-      allow(Rails.logger).to receive(:error)
-
-      find(:css, '#agreement').set(true)
-      click_on('Save')
-
-      visit('/dashboard/my/works')
-      click_link('A Work with a Virus')
-
-      expect(Rails.logger)
-        .to have_received(:error)
-        .with(/Virus.*virus_check\.txt/m)
-
-      # does not attach the virus file; deletes it from disk
-      expect(Hyrax::UploadedFile.select { |f| f.file.file.exists? }.count).to eq 1
-
-      # Check that a notification is created
-      find(:css, '.notify-number').click
-      expect(page).to have_content('virus')
+    within('#addfiles') do
+      attach_file('files[]', safe_path, visible: false, wait: 5)
+      attach_file('files[]', virus_path, visible: false, wait: 5)
     end
+
+    click_link('Descriptions')
+    fill_in 'Title', with: 'A Work with a Virus'
+    fill_in 'Creator', with: 'Dmitri Ivanovsky'
+    fill_in 'Keyword', with: 'pathogens'
+    select('No Known Copyright', from: 'Rights')
+
+    allow(Rails.logger).to receive(:error)
+
+    find(:css, '#agreement').set(true)
+    click_on('Save')
+
+    visit('/dashboard/my/works')
+    click_link('A Work with a Virus')
+
+    expect(Rails.logger)
+      .to have_received(:error)
+      .with(/Virus.*virus_check\.txt/m)
+
+    # does not attach the virus file; deletes it from disk
+    expect(Hyrax::UploadedFile.select { |f| f.file.file.exists? }.count).to eq 1
+
+    # Check that a notification is created
+    find(:css, '.notify-number').click
+    expect(page).to have_content('virus')
   end
 end


### PR DESCRIPTION
* Use partial to DRY up view warnings
* More consistent API (all related methods give booleans, rather than some being empty / non-empty strings and others booleans)
* Make it so that previous pending test runs 