### PR TITLE
Use db:setup rather than db:migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Development
     Using /Users/max/.rvm/gems/ruby-2.6.3 with gemset tenejo
     ```
 1. Run `bundle install`
-1. Run `bundle exec rails db:migrate` to setup the development database and schema.
+1. Run `bundle exec rails db:setup` to setup the development database and schema.
 1. Start the servers, one per terminal window/tab - `bundle exec fcrepo_wrapper`, `bundle exec solr_wrapper`, `bundle exec rails server`, and `bundle exec sidekiq`
 ### User and workflow setup
 1. (optional) Create standard accounts: `bundle exec rails tenejo:standard_users_setup`.


### PR DESCRIPTION
Used this post to uninstall postgres and try setting up according to new instructions.

https://blog.testdouble.com/posts/2021-01-28-how-to-completely-uninstall-homebrew-postgres/

Before `rails db:setup`
![image](https://user-images.githubusercontent.com/45948126/130252606-704a48b5-f0a8-4fab-b1da-287ca4de4140.png)

After `rails db:setup`
![image](https://user-images.githubusercontent.com/45948126/130252688-88465f09-86b6-4746-8e5c-e7b68dc95886.png)
