### PR TITLE
Add a feature flipper to switch between new and old UI

### DIFF
--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -1,31 +1,35 @@
-  <% if can? :review, :submissions %>
-    <li class="h5"><%= t('hyrax.admin.sidebar.tasks') %></li>
-    <%= menu.nav_link(hyrax.admin_workflows_path) do %>
-      <span class="fa fa-flag"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.workflow_review') %></span>
+<% if can? :review, :submissions %>
+  <li class="h5"><%= t('hyrax.admin.sidebar.tasks') %></li>
+  <%= menu.nav_link(hyrax.admin_workflows_path) do %>
+    <span class="fa fa-flag"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.workflow_review') %></span>
+  <% end %>
+<% end %>
+
+<% if current_user.admin? %>
+  <%= menu.nav_link(hyrax.admin_users_path) do %>
+    <span class="fa fa-user"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.users') %></span>
+  <% end %>
+<% end %>
+
+<% if current_user.admin? %>
+  <%= menu.nav_link('/roles/') do %>
+    <span class="fa fa-id-card"></span> <span class="sidebar-action-text">Manage User Roles</span>
+  <% end %>
+<% end %>
+
+<% if current_user.admin? %>
+  <%= menu.nav_link('/sidekiq/',  data: { turbolinks: false }) do %>
+    <span class="fa fa-line-chart"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.sidekiq') %></span>
+  <% end %>
+<% end %>
+
+<% if current_user.admin? && Flipflop.import_csv? %>
+  <% if Flipflop.new_ui? %>
+    <%= menu.nav_link('/csv_imports/new',  data: { turbolinks: false }) do %>
+      <span class="fa fa-upload"></span> <span class="sidebar-action-text">Bulk Operations</span>
     <% end %>
-  <% end %>
-
-  <% if current_user.admin? %>
-    <%= menu.nav_link(hyrax.admin_users_path) do %>
-      <span class="fa fa-user"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.users') %></span>
-    <% end %>
-  <% end %>
-
-  <% if current_user.admin? %>
-    <%= menu.nav_link('/roles/') do %>
-      <span class="fa fa-id-card"></span> <span class="sidebar-action-text">Manage User Roles</span>
-    <% end %>
-  <% end %>
-
-  <% if current_user.admin? %>
-      <%= menu.nav_link('/sidekiq/',  data: { turbolinks: false }) do %>
-          <span class="fa fa-line-chart"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.sidekiq') %></span>
-      <% end %>
-  <% end %>
-
-<% if Flipflop.import_csv? %>
-  <% if current_user.admin? %>
-  <%= menu.nav_link('/csv_imports/new',  data: { turbolinks: false }) do %>
+  <% else %>
+    <%= menu.nav_link('/csv_imports/new',  data: { turbolinks: false }) do %>
       <span class="fa fa-upload"></span> <span class="sidebar-action-text">Import Content From a CSV</span>
     <% end %>
   <% end %>

--- a/config/features.rb
+++ b/config/features.rb
@@ -8,6 +8,10 @@ Flipflop.configure do
           default: true,
           description: "Allow the user to start a CSV import from the dashboard."
 
+  feature :new_ui,
+          default: true,
+          description: "Show new UI features and workflows."
+
   feature :read_only,
           default: false,
           description: "Put the system into read-only mode. Deposits, edits, approvals and anything that makes a change to the data will be disabled."

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -4,6 +4,11 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 RSpec.describe 'Dashboard', type: :system do
+  before do
+    test_strategy = Flipflop::FeatureSet.current.test!
+    test_strategy.switch!(:new_ui, false)
+  end
+
   context 'as a regular user' do
     let(:user) { FactoryBot.create(:user) }
 


### PR DESCRIPTION
We want to begin experimenting with breaking changes to user flows in the UI.
And we want to be able to easily compare changes with the current state and
fallback if required.  Therefore we're introducing a feature flipper and
wrapping UI additions, changes, and deletion in a toggle.

This change also cleans up indentation in the the _task partial.

![image](https://user-images.githubusercontent.com/3064318/131387866-15ecf502-74a7-45e5-9d09-1b23b8394c43.png)

**New UI Off (old UI)**
![image](https://user-images.githubusercontent.com/3064318/131388019-6d26e653-d255-4979-911c-6ea55f9ba970.png)

**New UI On (trivial change for demonstration)**
![image](https://user-images.githubusercontent.com/3064318/131388118-3b603b2a-8569-4b69-bb29-1ba886ff12cf.png)
