### PR TITLE
Add a toggle-able batch operations group to the dashboard menu

### DIFF
--- a/app/extensions/menu_presenter.rb
+++ b/app/extensions/menu_presenter.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+# Extensions to the dashboard menu presenter to support batch operation sidebar toggles
+module TenejoExtensions
+  module MenuExtenders
+    Hyrax::MenuPresenter.class_eval do
+      # @return [Boolean] true if the current controller happens to be one of the controllers that deals
+      # with batch operations  This is used to keep the parent section on the sidebar open.
+      def batch_operations_section?
+        [Zizia::CsvImportsController,
+         Zizia::CsvImportDetailsController,
+         Zizia::ImporterDocumentationController].include? controller.class
+      end
+    end
+  end
+end

--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -17,18 +17,30 @@
   <% end %>
 <% end %>
 
-<% if current_user.admin? %>
-  <%= menu.nav_link('/sidekiq/',  data: { turbolinks: false }) do %>
-    <span class="fa fa-line-chart"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.sidekiq') %></span>
-  <% end %>
-<% end %>
-
 <% if current_user.admin? && Flipflop.import_csv? %>
   <% if Flipflop.new_ui? %>
-    <%= menu.nav_link('/csv_imports/new',  data: { turbolinks: false }) do %>
-      <span class="fa fa-upload"></span> <span class="sidebar-action-text">Bulk Operations</span>
-    <% end %>
+    <%# New UI - toggle group %>
+    <li>
+      <%= menu.collapsable_section 'Batch Operations',
+                                   icon_class: "fa fa-tasks",
+                                   id: 'collapseBatchOperations',
+                                   open: menu.batch_operations_section? do %>
+        <%= menu.nav_link('/importer_documentation/guide', title: 'CSV Import Field Guide', data: { turbolinks: false }) do %>
+          <span class="fa fa-book"></span> <span class="sidebar-action-text">Field Guide</span>
+        <% end %>
+        <%= menu.nav_link('/csv_imports/new', title: 'Import content using a CSV file', data: { turbolinks: false }) do %>
+          <span class="fa fa-arrow-right"></span> <span class="sidebar-action-text">Import</span>
+        <% end %>
+        <%= menu.nav_link('/csv_import_details/index', title: 'CSV Import history', data: { turbolinks: false }) do %>
+          <span class="fa fa-hourglass-half"></span> <span class="sidebar-action-text">Status</span>
+        <% end %>
+        <%= menu.nav_link('/sidekiq/',  data: { turbolinks: false }) do %>
+          <span class="fa fa-line-chart"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.sidekiq') %></span>
+        <% end %>
+      <% end %>
+    </li>
   <% else %>
+    <%# Old UI %>
     <%= menu.nav_link('/csv_imports/new',  data: { turbolinks: false }) do %>
       <span class="fa fa-upload"></span> <span class="sidebar-action-text">Import Content From a CSV</span>
     <% end %>

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -294,3 +294,4 @@ Qa::Authorities::Local.register_subauthority('languages', 'Qa::Authorities::Loca
 Qa::Authorities::Local.register_subauthority('genres', 'Qa::Authorities::Local::TableBasedAuthority')
 # load our extensions to hyrax after hyrax/hydra has been configured & monkeypatched already
 require './app/extensions/derivatives.rb'
+require './app/extensions/menu_presenter.rb'


### PR DESCRIPTION
We're trying to improve usability by making functions related to
batch operations easier to find.  Rather than having to navigate
to the main import page and then click to documentation or navigate
to a status page from there, this change gives direct links to those
functions in the left navigation bar in the dashboard.

**Menu Closed**
![image](https://user-images.githubusercontent.com/3064318/131438567-deb01fb0-a41c-483e-92a4-fdd77aaf5d26.png)

**Menu Open**
![image](https://user-images.githubusercontent.com/3064318/131438638-45dc942e-1484-4dfd-b42d-d0c9994da533.png)
