### PR TITLE
Keep the batch menu open when viewing the Field Guide

### DIFF
--- a/app/extensions/menu_presenter.rb
+++ b/app/extensions/menu_presenter.rb
@@ -8,7 +8,8 @@ module TenejoExtensions
       def batch_operations_section?
         [Zizia::CsvImportsController,
          Zizia::CsvImportDetailsController,
-         Zizia::ImporterDocumentationController].include? controller.class
+         Zizia::ImporterDocumentationController,
+         Zizia::MetadataDetailsController].include? controller.class
       end
     end
   end


### PR DESCRIPTION
The original commit was missing the Zizia field guide controller,
causing the sidebar to collapse when you clicked on the Field
Guide.  Thich change adds the controller name so the toggle menu
stays expanded while viewing the Field Guide.