### PR TITLE
Use ./tmp for test data files

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -5,8 +5,11 @@ GEONAMES_USERNAME=tenejodemo
 RAILS_SERVE_STATIC_FILES=true
 SIDEKIQ_WORKERS=5
 
-#export UPLOAD_PATH=tmp/uploads
-#export CACHE_PATH=tmp/uploads/cache
-#export WORKING_PATH=tmp/uploads
+export UPLOAD_PATH=tmp/test/uploads
+export CACHE_PATH=tmp/test/uploads/cache
+export WORKING_PATH=tmp/test/uploads
+DERIVATIVES_PATH=tmp/test/derivatives
+IMPORT_PATH=tmp/test/import
+
 SOLR_TEST_URL=http://localhost:8985/solr/hydra-test
 FEDORA_TEST_URL=http://localhost:8986/rest


### PR DESCRIPTION
**ISSUE**
On a clean new development environment, the test suite complains about
not having access to `/opt` with an error similar to this:
```
  3) ModularImporter imports a csv
     Failure/Error: expect { ModularImporter.new(csv_import).import }.to change { Work.count }.by 2

     Errno::EACCES:
       Permission denied @ dir_s_mkdir - /opt/uploads
```
Rather than requiring an opt folder in the development & test enviroments
that could accidentally get shared across applications and test suites,
this change sets all test data to be stored under the application's
`./tmp` directory.