### PR TITLE
Fixes for footer layouts on patron and admin views

### DIFF
--- a/app/views/layouts/hyrax/dashboard.html.erb
+++ b/app/views/layouts/hyrax/dashboard.html.erb
@@ -28,11 +28,14 @@
 
         <a name="skip-to-content" id="skip-to-content"></a>
         <%= content_for?(:content) ? yield(:content) : yield %>
-        <%= render 'shared/footer' %>
+     
+        <%= render 'shared/footer_content' %>
+     
       </div>
 
 
-    </div><!-- /#content-wrapper -->
+    </div>
+    <!-- /#content-wrapper -->
     <%= render 'shared/ajax_modal' %>
   </body>
 </html>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,15 +1,3 @@
 <footer class="navbar navbar-inverse">
-  <div class="container-fluid">
-    <div class="navbar-text text-left">
-      <p><%= t('hyrax.footer.service_html') %></p>
-      <p><%= t('hyrax.product_name') %> v<%= Hyrax::VERSION %></p>
-      <p><%= t('zizia.product_name') %> <span title="<%= Zizia::VERSION %>">v<%= Zizia::VERSION %></p>
-    </div>
-    <div class="navbar-right">
-      <div class="navbar-text text-right">
-        <p><%= t('tenejo.product_name') %> <span title="<%= GIT_SHA %>"><%= DEPLOYED_VERSION %>; <%= LAST_DEPLOYED %></span></p>
-        <p><%= t('hyrax.footer.copyright_html', :year=>Time.now.year) %></p>
-      </div>
-    </div>
-  </div>
+  <%= render 'shared/footer_content' %>
 </footer>

--- a/app/views/shared/_footer_content.html.erb
+++ b/app/views/shared/_footer_content.html.erb
@@ -1,14 +1,18 @@
-<div id="content-wrapper" role="main">
-  <div class="container-fluid">
-    <div class="navbar-text text-left">
-      <p><%= t('hyrax.footer.service_html') %></p>
-      <p><%= t('hyrax.product_name') %> v<%= Hyrax::VERSION %></p>
-    </div>
-    <div class="navbar-right">
-      <div class="navbar-text text-right">
-        <p><%= t('tenejo.product_name') %> <span title="<%= GIT_SHA %>"><%= DEPLOYED_VERSION %>; <%= LAST_DEPLOYED %></span></p>
-        <p><%= t('hyrax.footer.copyright_html', :year => Time.now.year) %></p>
-      </div>
+<div class="container-fluid">
+  <div class="navbar-text text-left">
+    <p><%= t('hyrax.footer.service_html') %></p>
+    <p><%= t('hyrax.product_name') %>
+      v<%= Hyrax::VERSION %></p>
+    <p><%= t('zizia.product_name') %>
+      <span title="<%= Zizia::VERSION %>">v<%= Zizia::VERSION %></p>
+  </div>
+  <div class="navbar-right">
+    <div class="navbar-text text-right">
+      <p><%= t('tenejo.product_name') %>
+        <span title="<%= GIT_SHA %>"><%= DEPLOYED_VERSION %>;
+          <%= LAST_DEPLOYED %></span>
+      </p>
+      <p><%= t('hyrax.footer.copyright_html', :year=>Time.now.year) %></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
The current footer breaks the layout in the admin views because it used the old patron views. This solution keeps the information as a partial while making the style changes on the layout pages

![screencapture-tenejo-curationexperts-admin-users-2021-09-30-11_00_48](https://user-images.githubusercontent.com/8102/135491913-5e01f456-a2cc-44b0-9caa-90b7f3493226.png)


![screencapture-localhost-3000-admin-users-2021-09-30-11_08_44](https://user-images.githubusercontent.com/8102/135491907-efaafa1f-9004-4276-8b09-82bb89b46894.png)
.