### PR TITLE
Default to 2 sidekiq workers

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -12,4 +12,4 @@
     :logfile: ./log/sidekiq_development.log
 
   production:
-    :concurrency: <%= ENV['SIDEKIQ_WORKERS'] || 5 %>
+    :concurrency: <%= ENV['SIDEKIQ_WORKERS'] || 2 %>


### PR DESCRIPTION
We've found that running 5 workers causes too much contention and that running 2 workers is more efficient on a t3a.xlarge instance.